### PR TITLE
chore: add Dockerfile and Makefile targets for docker build/push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Copyright(c) 2024 Beijing Yingfei Networks Technology Co.Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+.svn
+.tmp
+.download
+output/
+.*.swp
+.*.swo
+/**/y.output
+/**/*.log
+/**/*.log.*
+profile.out
+coverage.txt
+.idea/*
+.vscode/*
+.github
+dist/*
+conf/wasm_plugin
+
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,92 @@
+# Copyright(c) 2024 Beijing Yingfei Networks Technology Co.Ltd. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM --platform=${BUILDPLATFORM} golang:1.22.2-alpine3.19 AS build
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG ALPINE_MIRROR=
+
+WORKDIR /src
+
+RUN set -ex; \
+  if [ -n "${ALPINE_MIRROR}" ]; then \
+    echo "${ALPINE_MIRROR}/v3.19/main" > /etc/apk/repositories; \
+    echo "${ALPINE_MIRROR}/v3.19/community" >> /etc/apk/repositories; \
+  fi; \
+  apk add --no-cache git ca-certificates curl
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ENV CGO_ENABLED=0
+ENV GOTOOLCHAIN=local
+RUN set -ex; \
+  GOOS=${TARGETOS:-linux} \
+  GOARCH=${TARGETARCH:-$(go env GOARCH)} \
+  go build -trimpath -ldflags "-s -w" -o /out/api-server ./
+
+# Dashboard download stage
+FROM --platform=${BUILDPLATFORM} alpine:3.19 AS dashboard
+
+ARG ALPINE_MIRROR=
+ARG DASHBOARD_VERSION=v0.0.1
+
+RUN set -ex; \
+  if [ -n "${ALPINE_MIRROR}" ]; then \
+    echo "${ALPINE_MIRROR}/v3.19/main" > /etc/apk/repositories; \
+    echo "${ALPINE_MIRROR}/v3.19/community" >> /etc/apk/repositories; \
+  fi; \
+  apk add --no-cache curl tar; \
+  curl -fsSL -o /tmp/dashboard.tar.gz \
+    "https://github.com/yf-networks/ai-gateway-web/releases/download/${DASHBOARD_VERSION}/ai-gateway-web_${DASHBOARD_VERSION#v}.tar.gz"; \
+
+  mkdir -p /dashboard; \
+  tar -C /dashboard -zxf /tmp/dashboard.tar.gz; \
+  rm /tmp/dashboard.tar.gz
+
+# Final runtime stage
+FROM alpine:3.19
+
+ARG ALPINE_MIRROR=
+
+RUN set -ex; \
+  if [ -n "${ALPINE_MIRROR}" ]; then \
+    echo "${ALPINE_MIRROR}/v3.19/main" > /etc/apk/repositories; \
+    echo "${ALPINE_MIRROR}/v3.19/community" >> /etc/apk/repositories; \
+  fi; \
+  apk add --no-cache ca-certificates tzdata; \
+  addgroup -S app; \
+  adduser -S -G app -u 10001 app
+
+RUN mkdir -p /home/work/api-server/static
+
+WORKDIR /home/work/api-server
+
+COPY --from=build /out/api-server ./api-server
+COPY --from=dashboard /dashboard/ai-gateway-web_* /dashboard_tmp
+RUN cp -r /dashboard_tmp/* ./static/ && rm -rf /dashboard_tmp
+COPY conf ./conf
+
+RUN mkdir -p ./log \
+  && chown -R app:app /home/work/api-server
+
+USER app
+
+EXPOSE 8183 8284
+
+ENTRYPOINT ["./api-server"]
+CMD ["-c","./conf/","-sc","ai_gateway_api.toml","-l","./log"]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Copyright(c) 2024 Beijing Yingfei Networks Technology Co.Ltd. All rights reserved.
 # Copyright (c) 2019 The BFE Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +16,30 @@
 # init project path
 HOMEDIR := $(shell pwd)
 OUTDIR  := $(HOMEDIR)/output
+
+
+# -----------------------------------------------------------------------------
+# Container image build variables (used by docker/docker-push targets)
+# -----------------------------------------------------------------------------
+
+# Image name and version
+BFE_IMAGE_NAME ?= ai-gateway-api
+BFE_VERSION ?= $(shell sed -nE 's/^const Version = "([^"]+)"/\1/p' version/version.go)
+VERSION_TAG := v$(BFE_VERSION)
+
+# Registry and build settings
+REGISTRY ?=
+PLATFORMS ?= linux/amd64,linux/arm64
+BUILDER_NAME ?= ai-gateway-api-builder
+NO_CACHE ?= false
+DOCKER_BUILD_ARGS ?=
+
+# Derived tags
+IMAGE_LOCAL := $(BFE_IMAGE_NAME):$(VERSION_TAG)
+IMAGE_LATEST_LOCAL := $(BFE_IMAGE_NAME):latest
+IMAGE_REMOTE := $(if $(REGISTRY),$(REGISTRY)/$(BFE_IMAGE_NAME):$(VERSION_TAG),)
+IMAGE_LATEST_REMOTE := $(if $(REGISTRY),$(REGISTRY)/$(BFE_IMAGE_NAME):latest,)
+# -----------------------------------------------------------------------------
 
 # init command params
 GO      := $(GO_1_16_BIN)go
@@ -60,6 +85,27 @@ package-bin:
 	cp -rf  db_ddl.sql 	$(OUTDIR)/
 	cp -rf  *.md 		$(OUTDIR)/
 	mv ai-gateway-api  		$(OUTDIR)/
+
+
+# make docker
+docker:
+	docker build $(if $(filter 1 true TRUE True,$(NO_CACHE)),--no-cache,) $(DOCKER_BUILD_ARGS) \
+		-t $(IMAGE_LOCAL) \
+		-t $(IMAGE_LATEST_LOCAL) \
+		.
+
+# make docker-push (multi-arch)
+docker-push:
+	@test -n "$(REGISTRY)" || (echo "REGISTRY is required, e.g. REGISTRY=ghcr.io/your-org" && exit 1)
+	@docker buildx inspect $(BUILDER_NAME) >/dev/null 2>&1 || docker buildx create --name $(BUILDER_NAME) --driver docker-container --use
+	@docker buildx use $(BUILDER_NAME)
+	@docker buildx inspect --bootstrap >/dev/null
+	docker buildx build $(if $(filter 1 true TRUE True,$(NO_CACHE)),--no-cache,) $(DOCKER_BUILD_ARGS) \
+		--platform $(PLATFORMS) \
+		--push \
+		-t $(IMAGE_REMOTE) \
+		-t $(IMAGE_LATEST_REMOTE) \
+		.
 
 # make license-eye-install
 license-eye-install:

--- a/docs/zh_cn/build_docker.md
+++ b/docs/zh_cn/build_docker.md
@@ -1,0 +1,84 @@
+# Docker 镜像构建与推送
+
+## 前置条件
+
+- 已安装 Docker（建议较新版本）
+- 需要多架构推送时：Docker Buildx 可用（Docker Desktop 默认已带）
+- 推送镜像前请先登录镜像仓库：例如 `docker login <registry>`
+
+## 镜像内目录结构与挂载配置
+
+镜像运行时的工作目录为：
+
+- `/home/work/api-server`
+
+该目录下的关键文件/目录如下：
+
+- `/home/work/api-server/api-server`：服务二进制
+- `/home/work/api-server/conf/`：配置目录（默认会 COPY 进镜像，可通过 volume 覆盖）
+- `/home/work/api-server/static/`：静态资源目录（dashboard 解压后在这里）
+- `/home/work/api-server/log/`：日志目录（启动参数 `-l ./log`）
+
+### 挂载配置（推荐）
+
+你可以通过挂载本地 `conf` 目录来覆盖镜像内默认配置。例如：
+
+```bash
+docker run -d \
+	--name ai-gateway-api \
+	-p 8183:8183 \
+	-v $(pwd)/conf:/home/work/api-server/conf \
+	ai-gateway-api:latest
+```
+
+## 本地构建（make docker）
+
+Makefile 提供 `make docker` 目标用于本地构建。
+
+### 默认行为
+
+- 镜像名：`ai-gateway-api`
+- 默认会生成两份本地 tag：
+    - `ai-gateway-api:v<Version>`
+    - `ai-gateway-api:latest`
+
+### 常用参数
+
+可通过环境变量覆盖：
+
+- DASHBOARD_VERSION : 控制面版本，来自 `yf-networks/ai-gateway-web` 的 release 包
+
+示例：
+
+```bash
+make docker DASHBOARD_VERSION=v0.0.1'
+```
+
+## 多架构构建并推送（make docker-push）
+
+Makefile 提供 `make docker-push` 目标用于 **buildx 多架构** 构建并推送到远端仓库。
+
+### 必填参数
+
+- `REGISTRY`：镜像仓库前缀（必填），例如：
+	- `ghcr.io/<org>`
+	- `docker.io/<namespace>`
+	- `registry.example.com/<project>`
+
+推送的远端 tag：
+
+- `<REGISTRY>/<BFE_IMAGE_NAME>:v<Version>`
+- `<REGISTRY>/<BFE_IMAGE_NAME>:latest`
+
+### 可选参数
+
+- `PLATFORMS`：多架构平台（默认 `linux/amd64,linux/arm64`）
+
+示例：
+
+```bash
+# 指定平台
+make docker-push \
+	REGISTRY=ghcr.io/cc14514 \
+	PLATFORMS=linux/amd64
+```


### PR DESCRIPTION
This PR adds basic containerization support for ai-gateway-api to simplify local image builds and publishing.

Changes:

- Add Dockerfile for building the service image
- Update Makefile to include:
  - make docker for building the Docker image locally
  - make docker-push for pushing the image to a remote registry