### PR TITLE
fix(openapi): use iauth.FA instead of iauth.FAP for /clusters endpoints

### DIFF
--- a/endpoints/openapi_v1/product_cluster/create.go
+++ b/endpoints/openapi_v1/product_cluster/create.go
@@ -133,7 +133,7 @@ var CreateEndpoint = &xreq.Endpoint{
 	Path:       "/clusters",
 	Method:     http.MethodPost,
 	Handler:    xreq.Convert(CreateAction),
-	Authorizer: iauth.FAP(iauth.FeatureProductCluster, iauth.ActionCreate),
+	Authorizer: iauth.FA(iauth.FeatureProductCluster, iauth.ActionCreate),
 }
 
 var (

--- a/endpoints/openapi_v1/product_cluster/delete.go
+++ b/endpoints/openapi_v1/product_cluster/delete.go
@@ -30,7 +30,7 @@ var DeleteEndpoint = &xreq.Endpoint{
 	Path:       "/clusters/{cluster_name}",
 	Method:     http.MethodDelete,
 	Handler:    xreq.Convert(DeleteAction),
-	Authorizer: iauth.FAP(iauth.FeatureProductCluster, iauth.ActionDelete),
+	Authorizer: iauth.FA(iauth.FeatureProductCluster, iauth.ActionDelete),
 }
 
 func deleteActionProcess(req *http.Request, param *OneParam) (*ClusterData, error) {

--- a/endpoints/openapi_v1/product_cluster/list.go
+++ b/endpoints/openapi_v1/product_cluster/list.go
@@ -29,7 +29,7 @@ var ListEndpoint = &xreq.Endpoint{
 	Path:       "/clusters",
 	Method:     http.MethodGet,
 	Handler:    xreq.Convert(ListAction),
-	Authorizer: iauth.FAP(iauth.FeatureProductCluster, iauth.ActionRead),
+	Authorizer: iauth.FA(iauth.FeatureProductCluster, iauth.ActionRead),
 }
 
 func listActionProcess(req *http.Request) ([]*ClusterData, error) {

--- a/endpoints/openapi_v1/product_cluster/one.go
+++ b/endpoints/openapi_v1/product_cluster/one.go
@@ -181,7 +181,7 @@ var OneEndpoint = &xreq.Endpoint{
 	Path:       "/clusters/{cluster_name}",
 	Method:     http.MethodGet,
 	Handler:    xreq.Convert(OneAction),
-	Authorizer: iauth.FAP(iauth.FeatureProductCluster, iauth.ActionRead),
+	Authorizer: iauth.FA(iauth.FeatureProductCluster, iauth.ActionRead),
 }
 
 // AUTO GEN BY ctrl, MODIFY AS U NEED

--- a/endpoints/openapi_v1/product_cluster/ready.go
+++ b/endpoints/openapi_v1/product_cluster/ready.go
@@ -37,7 +37,7 @@ var ReadyEndpoint = &xreq.Endpoint{
 	Path:       "/clusters/{cluster_name}/ready",
 	Method:     http.MethodGet,
 	Handler:    xreq.Convert(ReadyAction),
-	Authorizer: iauth.FAP(iauth.FeatureProductCluster, iauth.ActionRead),
+	Authorizer: iauth.FA(iauth.FeatureProductCluster, iauth.ActionRead),
 }
 
 // AUTO GEN BY ctrl, MODIFY AS U NEED

--- a/endpoints/openapi_v1/product_cluster/update_basic.go
+++ b/endpoints/openapi_v1/product_cluster/update_basic.go
@@ -44,7 +44,7 @@ var UpdateBasicEndpoint = &xreq.Endpoint{
 	Path:       "/clusters/{cluster_name}",
 	Method:     http.MethodPatch,
 	Handler:    xreq.Convert(UpdateAction),
-	Authorizer: iauth.FAP(iauth.FeatureProductCluster, iauth.ActionUpdate),
+	Authorizer: iauth.FA(iauth.FeatureProductCluster, iauth.ActionUpdate),
 }
 
 // AUTO GEN BY ctrl, MODIFY AS U NEED


### PR DESCRIPTION
OpenAPI v0.3.0 moved /clusters paths out of product scope, but the endpoints still used iauth.FAP which requires a product context. This caused POST /open-api/v1/clusters (and other cluster endpoints) to fail with 'Param Illegal: Fail To Get Product' for non-admin tokens.

Fixes yf-networks/ai-gateway-api#27