### PR TITLE
test: add unit tests for stateful and storage packages

### DIFF
--- a/endpoints/innerapi_v1/ai_route/export_test.go
+++ b/endpoints/innerapi_v1/ai_route/export_test.go
@@ -1,0 +1,148 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ai_route
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/endpoints/innerapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+	"github.com/yf-networks/ai-gateway-api/model/imods"
+	"github.com/yf-networks/ai-gateway-api/model/quota"
+	"github.com/yf-networks/ai-gateway-api/model/shared"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeAPIKeyStoragerForAIRoute struct{}
+
+func (f *fakeAPIKeyStoragerForAIRoute) FetchAPIKeyList(ctx context.Context, filter *icluster_conf.APIKeyFilter) ([]*icluster_conf.APIKeyParam, error) {
+	return nil, nil
+}
+
+func (f *fakeAPIKeyStoragerForAIRoute) CreateAPIKey(ctx context.Context, param *icluster_conf.APIKeyParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForAIRoute) UpdateAPIKey(ctx context.Context, filter *icluster_conf.APIKeyFilter, param *icluster_conf.APIKeyParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForAIRoute) DeleteAPIKey(ctx context.Context, filter *icluster_conf.APIKeyFilter) error {
+	return nil
+}
+
+func (f *fakeAPIKeyStoragerForAIRoute) CreateAPIKeyToken(ctx context.Context, param *icluster_conf.APIKeyTokenParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForAIRoute) UpdateAPIKeyToken(ctx context.Context, filter *icluster_conf.APIKeyTokenFilter, param *icluster_conf.APIKeyTokenParam) error {
+	return nil
+}
+
+func (f *fakeAPIKeyStoragerForAIRoute) FetchAPIKeyTokenList(ctx context.Context, filter *icluster_conf.APIKeyTokenFilter) ([]*icluster_conf.APIKeyTokenParam, error) {
+	return nil, nil
+}
+
+type fakeEntityStoragerForAIRoute struct{}
+
+func (f *fakeEntityStoragerForAIRoute) CreateEntity(ctx context.Context, param *quota.EntityParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeEntityStoragerForAIRoute) FetchEntity(ctx context.Context, filter *quota.EntityFilter) (*quota.EntityParam, error) {
+	return nil, nil
+}
+
+func (f *fakeEntityStoragerForAIRoute) FetchEntityList(ctx context.Context, filter *quota.EntityFilter) ([]*quota.EntityParam, error) {
+	return nil, nil
+}
+
+func (f *fakeEntityStoragerForAIRoute) UpdateEntity(ctx context.Context, filter *quota.EntityFilter, param *quota.EntityParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeEntityStoragerForAIRoute) DeleteEntity(ctx context.Context, filter *quota.EntityFilter) error {
+	return nil
+}
+
+type fakeRouteRulesStorager struct{}
+
+func (f *fakeRouteRulesStorager) CreateRouteRules(ctx context.Context, ruleType string, owner *string, param *shared.RouteRulesParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeRouteRulesStorager) FetchRouteRules(ctx context.Context, ruleType string, owner *string) (*shared.RouteRulesParam, error) {
+	return nil, nil
+}
+
+func (f *fakeRouteRulesStorager) FetchRouteRulesList(ctx context.Context, filter *shared.RouteRulesFilter) ([]*shared.RouteTableParam, int64, error) {
+	return nil, 0, nil
+}
+
+func (f *fakeRouteRulesStorager) UpdateRouteRules(ctx context.Context, id int64, param *shared.RouteRulesParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeRouteRulesStorager) DeleteRouteRules(ctx context.Context, id int64) error {
+	return nil
+}
+
+func (f *fakeRouteRulesStorager) FetchRouteRulesByID(ctx context.Context, id int64) (*shared.RouteRulesParam, error) {
+	return nil, nil
+}
+
+func setupAIRouteExporter(version string) func() {
+	old := container.AIRouteExporter
+	container.AIRouteExporter = imods.NewAIRouteExporter(
+		&fakeAPIKeyStoragerForAIRoute{},
+		&fakeEntityStoragerForAIRoute{},
+		&fakeRouteRulesStorager{},
+		testutil.NewVersionControlManager(version),
+	)
+	return func() {
+		container.AIRouteExporter = old
+	}
+}
+
+func TestExportAction(t *testing.T) {
+	defer setupAIRouteExporter("v2")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/ai-route?version=", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*imods.AiRouteDataExport)
+	require.True(t, ok)
+	assert.Equal(t, "v2", conf.Version)
+	assert.NotNil(t, conf.RouteRules)
+	assert.NotNil(t, conf.ApikeyRouteTableBindings)
+}
+
+func TestExportAction_VersionNotChanged(t *testing.T) {
+	defer setupAIRouteExporter("v1")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/ai-route?version=v1", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}

--- a/endpoints/innerapi_v1/endpoints_test.go
+++ b/endpoints/innerapi_v1/endpoints_test.go
@@ -1,0 +1,77 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package innerapi_v1
+
+import (
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoints(t *testing.T) {
+	eps := endpoints()
+	require.Len(t, eps, 9)
+
+	paths := make([]string, 0, len(eps))
+	for _, ep := range eps {
+		require.NotNil(t, ep)
+		if ep.RegisterHandler != nil {
+			paths = append(paths, "")
+		} else {
+			paths = append(paths, ep.Path)
+		}
+	}
+
+	assert.Equal(t, []string{
+		"/configs/tls_conf/server_data_conf",
+		"/configs/gslb_data/gslb",
+		"/configs/gslb_data/cluster_table",
+		"/configs/protocol/server_cert_conf",
+		"",
+		"/configs/mod-api-key",
+		"/configs/mod-body-process",
+		"/configs/rate-limit-policy",
+		"/configs/ai-route",
+	}, paths)
+}
+
+func TestRegisterRouter(t *testing.T) {
+	root := mux.NewRouter()
+	sub := RegisterRouter(root)
+
+	require.NotNil(t, sub)
+
+	var matchedPaths []string
+	err := sub.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		path, err := route.GetPathTemplate()
+		if err == nil {
+			matchedPaths = append(matchedPaths, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/tls_conf/server_data_conf")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/gslb_data/gslb")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/gslb_data/cluster_table")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/protocol/server_cert_conf")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/extra_files/")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/mod-api-key")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/mod-body-process")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/rate-limit-policy")
+	assert.Contains(t, matchedPaths, "/inner-api/v1/configs/ai-route")
+}

--- a/endpoints/innerapi_v1/export_util/param_test.go
+++ b/endpoints/innerapi_v1/export_util/param_test.go
@@ -1,0 +1,42 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package export_util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewExportFromReq(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/export?version=v1", nil)
+	param, err := NewExportFromReq(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, param)
+	assert.Equal(t, "v1", param.Version)
+}
+
+func TestNewExportFromReq_EmptyVersion(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/export", nil)
+	param, err := NewExportFromReq(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, param)
+	assert.Equal(t, "", param.Version)
+}

--- a/endpoints/innerapi_v1/extra_file/export_test.go
+++ b/endpoints/innerapi_v1/extra_file/export_test.go
@@ -1,0 +1,88 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extra_file
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/model/ibasic"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeExtraFileStorager struct {
+	fetchExtraFilesFn func(ctx context.Context, filter *ibasic.ExtraFileFilter) ([]*ibasic.ExtraFile, error)
+}
+
+func (f *fakeExtraFileStorager) CreateExtraFile(ctx context.Context, product *ibasic.Product, files ...*ibasic.ExtraFileParam) error {
+	return nil
+}
+
+func (f *fakeExtraFileStorager) DeleteExtraFile(ctx context.Context, filter *ibasic.ExtraFileFilter) error {
+	return nil
+}
+
+func (f *fakeExtraFileStorager) FetchExtraFiles(ctx context.Context, filter *ibasic.ExtraFileFilter) ([]*ibasic.ExtraFile, error) {
+	if f.fetchExtraFilesFn != nil {
+		return f.fetchExtraFilesFn(ctx, filter)
+	}
+	return nil, nil
+}
+
+func setupExtraFileManager(storager ibasic.ExtraFileStorager) func() {
+	old := container.ExtraFileManager
+	container.ExtraFileManager = ibasic.NewExtraFileManager(storager)
+	return func() {
+		container.ExtraFileManager = old
+	}
+}
+
+func TestExportExtraFileActionProcess_Success(t *testing.T) {
+	defer setupExtraFileManager(&fakeExtraFileStorager{
+		fetchExtraFilesFn: func(ctx context.Context, filter *ibasic.ExtraFileFilter) ([]*ibasic.ExtraFile, error) {
+			require.NotNil(t, filter.Name)
+			assert.Equal(t, "test.txt", *filter.Name)
+			return []*ibasic.ExtraFile{
+				{ID: 1, Name: "test.txt", Content: []byte("hello world")},
+			}, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/extra_files/test.txt", nil)
+	data, err := ExportExtraFileAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Equal(t, []byte("hello world"), data)
+}
+
+func TestExportExtraFileActionProcess_NotFound(t *testing.T) {
+	defer setupExtraFileManager(&fakeExtraFileStorager{
+		fetchExtraFilesFn: func(ctx context.Context, filter *ibasic.ExtraFileFilter) ([]*ibasic.ExtraFile, error) {
+			return nil, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/extra_files/missing.txt", nil)
+	data, err := ExportExtraFileAction(req)
+
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Contains(t, err.Error(), "Record Not Exist")
+}

--- a/endpoints/innerapi_v1/gslb_data/cluster_table_test.go
+++ b/endpoints/innerapi_v1/gslb_data/cluster_table_test.go
@@ -1,0 +1,94 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gslb_data
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+)
+
+func TestExportClusterTableAction(t *testing.T) {
+	defer setupClusterManager(&fakeClusterStorager{
+		fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+			return []*icluster_conf.Cluster{
+				{
+					Name: "cluster1",
+					SubClusters: []*icluster_conf.SubCluster{
+						{
+							Name: "sub1",
+							InstancePool: &icluster_conf.Pool{
+								Instances: []icluster_conf.Instance{
+									{HostName: "host1", IP: "10.0.0.1", Port: 8080, Weight: 100},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		fetchLBMatrixListFn: func(ctx context.Context) (map[int64]map[string]map[string]int, error) {
+			return nil, nil
+		},
+	}, "v2")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/gslb_data/cluster_table?version=", nil)
+	data, err := ExportClusterTableAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*icluster_conf.ClusterTableConf)
+	require.True(t, ok)
+	assert.Equal(t, "v2", *conf.Version)
+	require.NotNil(t, conf.Config)
+	assert.Contains(t, *conf.Config, "cluster1")
+}
+
+func TestExportClusterTableAction_VersionNotChanged(t *testing.T) {
+	defer setupClusterManager(&fakeClusterStorager{
+		fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+			return []*icluster_conf.Cluster{
+				{
+					Name: "cluster1",
+					SubClusters: []*icluster_conf.SubCluster{
+						{
+							Name: "sub1",
+							InstancePool: &icluster_conf.Pool{
+								Instances: []icluster_conf.Instance{
+									{HostName: "host1", IP: "10.0.0.1", Port: 8080, Weight: 100},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		fetchLBMatrixListFn: func(ctx context.Context) (map[int64]map[string]map[string]int, error) {
+			return nil, nil
+		},
+	}, "v1")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/gslb_data/cluster_table?version=v1", nil)
+	data, err := ExportClusterTableAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}

--- a/endpoints/innerapi_v1/gslb_data/common_test.go
+++ b/endpoints/innerapi_v1/gslb_data/common_test.go
@@ -1,0 +1,133 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gslb_data
+
+import (
+	"context"
+
+	"github.com/yf-networks/ai-gateway-api/endpoints/innerapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/model/ibasic"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeClusterStorager struct {
+	fetchClusterListFn func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error)
+	fetchLBMatrixListFn func(ctx context.Context) (map[int64]map[string]map[string]int, error)
+}
+
+func (f *fakeClusterStorager) FetchCluster(ctx context.Context, param *icluster_conf.ClusterFilter) (*icluster_conf.Cluster, error) {
+	return nil, nil
+}
+
+func (f *fakeClusterStorager) FetchClusterList(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+	if f.fetchClusterListFn != nil {
+		return f.fetchClusterListFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (f *fakeClusterStorager) ClusterUpdate(ctx context.Context, product *ibasic.Product, old *icluster_conf.Cluster, param *icluster_conf.ClusterParam) error {
+	return nil
+}
+
+func (f *fakeClusterStorager) ClusterCreate(ctx context.Context, product *ibasic.Product, param *icluster_conf.ClusterParam, subClusters []*icluster_conf.SubCluster) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeClusterStorager) ClusterDelete(ctx context.Context, product *ibasic.Product, cluster *icluster_conf.Cluster) error {
+	return nil
+}
+
+func (f *fakeClusterStorager) BindSubCluster(ctx context.Context, cluster *icluster_conf.Cluster, appendSubClusters, unbindSubClusters []*icluster_conf.SubCluster) error {
+	return nil
+}
+
+func (f *fakeClusterStorager) FetchLBMatrixList(ctx context.Context) (map[int64]map[string]map[string]int, error) {
+	if f.fetchLBMatrixListFn != nil {
+		return f.fetchLBMatrixListFn(ctx)
+	}
+	return nil, nil
+}
+
+type fakeSubClusterStorager struct{}
+
+func (f *fakeSubClusterStorager) FetchSubClusterList(ctx context.Context, param *icluster_conf.SubClusterFilter) ([]*icluster_conf.SubCluster, error) {
+	return nil, nil
+}
+
+func (f *fakeSubClusterStorager) CreateSubCluster(ctx context.Context, param *icluster_conf.SubClusterParam) error {
+	return nil
+}
+
+func (f *fakeSubClusterStorager) DeleteSubCluster(ctx context.Context, param *icluster_conf.SubCluster) error {
+	return nil
+}
+
+func (f *fakeSubClusterStorager) UpdateSubCluster(ctx context.Context, one *icluster_conf.SubCluster, param *icluster_conf.SubClusterParam) error {
+	return nil
+}
+
+type fakeBFEClusterStorager struct{}
+
+func (f *fakeBFEClusterStorager) DeleteBFECluster(ctx context.Context, cluster *ibasic.BFECluster) error {
+	return nil
+}
+
+func (f *fakeBFEClusterStorager) CreateBFECluster(ctx context.Context, param *ibasic.BFEClusterParam) error {
+	return nil
+}
+
+func (f *fakeBFEClusterStorager) FetchBFEClusters(ctx context.Context, param *ibasic.BFEClusterFilter) ([]*ibasic.BFECluster, error) {
+	return nil, nil
+}
+
+type fakePoolStorager struct{}
+
+func (f *fakePoolStorager) FetchPool(ctx context.Context, name string) (*icluster_conf.Pool, error) {
+	return nil, nil
+}
+
+func (f *fakePoolStorager) FetchPools(ctx context.Context, param *icluster_conf.PoolFilter) ([]*icluster_conf.Pool, error) {
+	return nil, nil
+}
+
+func (f *fakePoolStorager) CreatePool(ctx context.Context, product *ibasic.Product, data *icluster_conf.PoolParam) (*icluster_conf.Pool, error) {
+	return nil, nil
+}
+
+func (f *fakePoolStorager) UpdatePool(ctx context.Context, oldData *icluster_conf.Pool, diff *icluster_conf.PoolParam) error {
+	return nil
+}
+
+func (f *fakePoolStorager) DeletePool(ctx context.Context, pool *icluster_conf.Pool) error {
+	return nil
+}
+
+func setupClusterManager(storager icluster_conf.ClusterStorager, version string) func() {
+	old := container.ClusterManager
+	container.ClusterManager = icluster_conf.NewClusterManager(
+		&testutil.FakeTxn{},
+		storager,
+		&fakeSubClusterStorager{},
+		&fakeBFEClusterStorager{},
+		&fakePoolStorager{},
+		testutil.NewVersionControlManager(version),
+		nil,
+	)
+	return func() {
+		container.ClusterManager = old
+	}
+}

--- a/endpoints/innerapi_v1/gslb_data/gslb_test.go
+++ b/endpoints/innerapi_v1/gslb_data/gslb_test.go
@@ -1,0 +1,105 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gslb_data
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+)
+
+func TestExportGSLBAction(t *testing.T) {
+	defer setupClusterManager(&fakeClusterStorager{
+		fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+			return []*icluster_conf.Cluster{
+				{
+					Name: "cluster1",
+					Scheduler: map[string]map[string]int{
+						"bfe-cluster": {"sub1": 100},
+					},
+				},
+			}, nil
+		},
+	}, "v2")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/gslb_data/gslb?version=&bfe_cluster=bfe-cluster", nil)
+	data, err := ExportGSLBAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*icluster_conf.GSLBConf)
+	require.True(t, ok)
+	assert.Equal(t, "v2", conf.Version)
+	require.NotNil(t, conf.Clusters)
+	assert.Contains(t, *conf.Clusters, "cluster1")
+}
+
+func TestExportGSLBAction_VersionNotChanged(t *testing.T) {
+	defer setupClusterManager(&fakeClusterStorager{
+		fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+			return []*icluster_conf.Cluster{
+				{
+					Name: "cluster1",
+					Scheduler: map[string]map[string]int{
+						"bfe-cluster": {"sub1": 100},
+					},
+				},
+			}, nil
+		},
+	}, "v1")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/gslb_data/gslb?version=v1&bfe_cluster=bfe-cluster", nil)
+	data, err := ExportGSLBAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}
+
+func TestExportGSLBAction_MissingBFECluster(t *testing.T) {
+	defer setupClusterManager(&fakeClusterStorager{}, "v2")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/gslb_data/gslb?version=", nil)
+	_, err := ExportGSLBAction(req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BFECluster")
+}
+
+func TestExportGSLBAction_BFEClusterNotExist(t *testing.T) {
+	defer setupClusterManager(&fakeClusterStorager{
+		fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+			return []*icluster_conf.Cluster{
+				{
+					Name: "cluster1",
+					Scheduler: map[string]map[string]int{
+						"other-cluster": {"sub1": 100},
+					},
+				},
+			}, nil
+		},
+	}, "v2")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/gslb_data/gslb?version=&bfe_cluster=bfe-cluster", nil)
+	_, err := ExportGSLBAction(req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "BFECluster bfe-cluster Not Exist")
+}

--- a/endpoints/innerapi_v1/internal/testutil/testutil.go
+++ b/endpoints/innerapi_v1/internal/testutil/testutil.go
@@ -1,0 +1,50 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"context"
+
+	"github.com/yf-networks/ai-gateway-api/model/itxn"
+	"github.com/yf-networks/ai-gateway-api/model/iversion_control"
+)
+
+// FakeTxn is a no-op transaction storager used by unit tests.
+type FakeTxn struct{}
+
+func (f *FakeTxn) AtomExecute(ctx context.Context, do func(context.Context) error) error {
+	return do(ctx)
+}
+
+var _ itxn.TxnStorager = (*FakeTxn)(nil)
+
+// FakeVersionControlStorager implements iversion_control.VersionControlStorager.
+type FakeVersionControlStorager struct {
+	Version string
+}
+
+func (f *FakeVersionControlStorager) UpsertConfigLastExportedVersion(ctx context.Context, css *iversion_control.ExportData) (string, error) {
+	if f.Version != "" {
+		return f.Version, nil
+	}
+	return "v1", nil
+}
+
+var _ iversion_control.VersionControlStorager = (*FakeVersionControlStorager)(nil)
+
+// NewVersionControlManager creates a VersionControlManager backed by fake storagers.
+func NewVersionControlManager(version string) *iversion_control.VersionControlManager {
+	return iversion_control.NewVersionControllerManager(&FakeTxn{}, &FakeVersionControlStorager{Version: version})
+}

--- a/endpoints/innerapi_v1/mod_api_key/export_test.go
+++ b/endpoints/innerapi_v1/mod_api_key/export_test.go
@@ -1,0 +1,164 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mod_api_key
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/endpoints/innerapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/model/iai_route"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+	"github.com/yf-networks/ai-gateway-api/model/imods"
+	"github.com/yf-networks/ai-gateway-api/model/quota"
+	"github.com/yf-networks/ai-gateway-api/stateful"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeAPIKeyStoragerForRule struct{}
+
+func (f *fakeAPIKeyStoragerForRule) FetchAPIKeyList(ctx context.Context, filter *icluster_conf.APIKeyFilter) ([]*icluster_conf.APIKeyParam, error) {
+	return nil, nil
+}
+
+func (f *fakeAPIKeyStoragerForRule) CreateAPIKey(ctx context.Context, param *icluster_conf.APIKeyParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForRule) UpdateAPIKey(ctx context.Context, filter *icluster_conf.APIKeyFilter, param *icluster_conf.APIKeyParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForRule) DeleteAPIKey(ctx context.Context, filter *icluster_conf.APIKeyFilter) error {
+	return nil
+}
+
+func (f *fakeAPIKeyStoragerForRule) CreateAPIKeyToken(ctx context.Context, param *icluster_conf.APIKeyTokenParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForRule) UpdateAPIKeyToken(ctx context.Context, filter *icluster_conf.APIKeyTokenFilter, param *icluster_conf.APIKeyTokenParam) error {
+	return nil
+}
+
+func (f *fakeAPIKeyStoragerForRule) FetchAPIKeyTokenList(ctx context.Context, filter *icluster_conf.APIKeyTokenFilter) ([]*icluster_conf.APIKeyTokenParam, error) {
+	return nil, nil
+}
+
+type fakeAIRouteRuleStoragerForRule struct{}
+
+func (f *fakeAIRouteRuleStoragerForRule) FetchAIRouteRules(ctx context.Context, filter *iai_route.AIRouteFilter) ([]*iai_route.Rule, error) {
+	return nil, nil
+}
+
+func (f *fakeAIRouteRuleStoragerForRule) CreateAIRouteRules(ctx context.Context, param []*iai_route.Rule) error {
+	return nil
+}
+
+type fakeQuotaPlanStoragerForRule struct{}
+
+func (f *fakeQuotaPlanStoragerForRule) CreateQuotaPlan(ctx context.Context, param *quota.QuotaPlanParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeQuotaPlanStoragerForRule) FetchQuotaPlan(ctx context.Context, filter *quota.QuotaPlanFilter) (*quota.QuotaPlanParam, error) {
+	return nil, nil
+}
+
+func (f *fakeQuotaPlanStoragerForRule) FetchQuotaPlanList(ctx context.Context, filter *quota.QuotaPlanFilter) ([]*quota.QuotaPlanParam, error) {
+	return nil, nil
+}
+
+func (f *fakeQuotaPlanStoragerForRule) UpdateQuotaPlan(ctx context.Context, filter *quota.QuotaPlanFilter, param *quota.QuotaPlanParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeQuotaPlanStoragerForRule) DeleteQuotaPlan(ctx context.Context, filter *quota.QuotaPlanFilter) error {
+	return nil
+}
+
+type fakeEntityStoragerForRule struct{}
+
+func (f *fakeEntityStoragerForRule) CreateEntity(ctx context.Context, param *quota.EntityParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeEntityStoragerForRule) FetchEntity(ctx context.Context, filter *quota.EntityFilter) (*quota.EntityParam, error) {
+	return nil, nil
+}
+
+func (f *fakeEntityStoragerForRule) FetchEntityList(ctx context.Context, filter *quota.EntityFilter) ([]*quota.EntityParam, error) {
+	return nil, nil
+}
+
+func (f *fakeEntityStoragerForRule) UpdateEntity(ctx context.Context, filter *quota.EntityFilter, param *quota.EntityParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeEntityStoragerForRule) DeleteEntity(ctx context.Context, filter *quota.EntityFilter) error {
+	return nil
+}
+
+func setupAPIKeyRuleManager(version string) func() {
+	origConfig := stateful.DefaultConfig
+	stateful.DefaultConfig = &stateful.Config{
+		RunTime: stateful.RunTimeConfig{
+			AIRouteInnerProductName: "AI_product",
+		},
+	}
+
+	old := container.APIKeyRuleManager
+	container.APIKeyRuleManager = imods.NewAPIKeyRuleManager(
+		&testutil.FakeTxn{},
+		testutil.NewVersionControlManager(version),
+		&fakeAPIKeyStoragerForRule{},
+		&fakeAIRouteRuleStoragerForRule{},
+		&fakeQuotaPlanStoragerForRule{},
+		&fakeEntityStoragerForRule{},
+	)
+	return func() {
+		container.APIKeyRuleManager = old
+		stateful.DefaultConfig = origConfig
+	}
+}
+
+func TestExportAction(t *testing.T) {
+	defer setupAPIKeyRuleManager("v2")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/mod-api-key?version=", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*imods.ModAPIKeyRuleConf)
+	require.True(t, ok)
+	assert.Equal(t, "v2", *conf.Version)
+	assert.Contains(t, conf.Config, "AI_product")
+}
+
+func TestExportAction_VersionNotChanged(t *testing.T) {
+	defer setupAPIKeyRuleManager("v1")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/mod-api-key?version=v1", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}

--- a/endpoints/innerapi_v1/mod_body_process/export_test.go
+++ b/endpoints/innerapi_v1/mod_body_process/export_test.go
@@ -1,0 +1,71 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mod_body_process
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/endpoints/innerapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/model/imods"
+	"github.com/yf-networks/ai-gateway-api/stateful"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+func setupTestEnv(version string) func() {
+	origConfig := stateful.DefaultConfig
+	stateful.DefaultConfig = &stateful.Config{
+		RunTime: stateful.RunTimeConfig{
+			AIRouteInnerProductName: "AI_product",
+		},
+	}
+
+	old := container.ModBodyProcessManager
+	container.ModBodyProcessManager = imods.NewModBodyProcessManager(testutil.NewVersionControlManager(version))
+
+	return func() {
+		container.ModBodyProcessManager = old
+		stateful.DefaultConfig = origConfig
+	}
+}
+
+func TestExportAction(t *testing.T) {
+	defer setupTestEnv("v2")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/mod-body-process?version=", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*imods.ModBodyProcessConf)
+	require.True(t, ok)
+	assert.Equal(t, []string{}, conf.Config["AI_product"])
+	assert.Equal(t, "v2", *conf.Version)
+}
+
+func TestExportAction_VersionNotChanged(t *testing.T) {
+	defer setupTestEnv("v1")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/mod-body-process?version=v1", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}
+

--- a/endpoints/innerapi_v1/protocol/cert_export_test.go
+++ b/endpoints/innerapi_v1/protocol/cert_export_test.go
@@ -1,0 +1,121 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/endpoints/innerapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/model/ibasic"
+	"github.com/yf-networks/ai-gateway-api/model/iprotocol"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeCertificateStorager struct {
+	fetchCertificatesFn func(ctx context.Context, param *iprotocol.CertificateFilter) ([]*iprotocol.Certificate, error)
+}
+
+func (f *fakeCertificateStorager) FetchCertificates(ctx context.Context, param *iprotocol.CertificateFilter) ([]*iprotocol.Certificate, error) {
+	if f.fetchCertificatesFn != nil {
+		return f.fetchCertificatesFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (f *fakeCertificateStorager) DeleteCertificate(ctx context.Context, cert *iprotocol.Certificate) error {
+	return nil
+}
+
+func (f *fakeCertificateStorager) CreateCertificate(ctx context.Context, param *iprotocol.CertificateParam) error {
+	return nil
+}
+
+func (f *fakeCertificateStorager) UpdateCertificate(ctx context.Context, cert *iprotocol.Certificate, param *iprotocol.CertificateParam) error {
+	return nil
+}
+
+type fakeExtraFileStoragerForCert struct{}
+
+func (f *fakeExtraFileStoragerForCert) CreateExtraFile(ctx context.Context, product *ibasic.Product, files ...*ibasic.ExtraFileParam) error {
+	return nil
+}
+
+func (f *fakeExtraFileStoragerForCert) DeleteExtraFile(ctx context.Context, filter *ibasic.ExtraFileFilter) error {
+	return nil
+}
+
+func (f *fakeExtraFileStoragerForCert) FetchExtraFiles(ctx context.Context, filter *ibasic.ExtraFileFilter) ([]*ibasic.ExtraFile, error) {
+	return nil, nil
+}
+
+func setupCertificateManager(storager iprotocol.CertificateStorager) func() {
+	old := container.CertificateManager
+	container.CertificateManager = iprotocol.NewCertificateManager(&testutil.FakeTxn{}, storager, testutil.NewVersionControlManager("v2"), &fakeExtraFileStoragerForCert{})
+	return func() {
+		container.CertificateManager = old
+	}
+}
+
+func TestServerCertExportAction(t *testing.T) {
+	defer setupCertificateManager(&fakeCertificateStorager{
+		fetchCertificatesFn: func(ctx context.Context, param *iprotocol.CertificateFilter) ([]*iprotocol.Certificate, error) {
+			return []*iprotocol.Certificate{
+				{
+					CertName:     "default",
+					IsDefault:    true,
+					CertFilePath: "conf/default.crt",
+					KeyFilePath:  "conf/default.key",
+				},
+			}, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/protocol/server_cert_conf?version=", nil)
+	data, err := ServerCertExportAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*iprotocol.ServerCertConf)
+	require.True(t, ok)
+	assert.Equal(t, "default", conf.Config.Default)
+	assert.Contains(t, conf.Config.CertConf, "default")
+}
+
+func TestServerCertExportAction_VersionNotChanged(t *testing.T) {
+	defer setupCertificateManager(&fakeCertificateStorager{
+		fetchCertificatesFn: func(ctx context.Context, param *iprotocol.CertificateFilter) ([]*iprotocol.Certificate, error) {
+			return []*iprotocol.Certificate{
+				{
+					CertName:     "default",
+					IsDefault:    true,
+					CertFilePath: "conf/default.crt",
+					KeyFilePath:  "conf/default.key",
+				},
+			}, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/protocol/server_cert_conf?version=v2", nil)
+	data, err := ServerCertExportAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}

--- a/endpoints/innerapi_v1/rate_limit_policy/export_test.go
+++ b/endpoints/innerapi_v1/rate_limit_policy/export_test.go
@@ -1,0 +1,142 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rate_limit_policy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/endpoints/innerapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+	"github.com/yf-networks/ai-gateway-api/model/quota"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeRateLimitPolicyStorager struct{}
+
+func (f *fakeRateLimitPolicyStorager) CreateRateLimitPolicy(ctx context.Context, param *quota.RateLimitPolicyParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeRateLimitPolicyStorager) FetchRateLimitPolicy(ctx context.Context, filter *quota.RateLimitPolicyFilter) (*quota.RateLimitPolicyParam, error) {
+	return nil, nil
+}
+
+func (f *fakeRateLimitPolicyStorager) FetchRateLimitPolicyList(ctx context.Context, filter *quota.RateLimitPolicyFilter) ([]*quota.RateLimitPolicyParam, error) {
+	return nil, nil
+}
+
+func (f *fakeRateLimitPolicyStorager) UpdateRateLimitPolicy(ctx context.Context, filter *quota.RateLimitPolicyFilter, param *quota.RateLimitPolicyParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeRateLimitPolicyStorager) DeleteRateLimitPolicy(ctx context.Context, filter *quota.RateLimitPolicyFilter) error {
+	return nil
+}
+
+type fakeAPIKeyStoragerForRateLimit struct{}
+
+func (f *fakeAPIKeyStoragerForRateLimit) FetchAPIKeyList(ctx context.Context, filter *icluster_conf.APIKeyFilter) ([]*icluster_conf.APIKeyParam, error) {
+	return nil, nil
+}
+
+func (f *fakeAPIKeyStoragerForRateLimit) CreateAPIKey(ctx context.Context, param *icluster_conf.APIKeyParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForRateLimit) UpdateAPIKey(ctx context.Context, filter *icluster_conf.APIKeyFilter, param *icluster_conf.APIKeyParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForRateLimit) DeleteAPIKey(ctx context.Context, filter *icluster_conf.APIKeyFilter) error {
+	return nil
+}
+
+func (f *fakeAPIKeyStoragerForRateLimit) CreateAPIKeyToken(ctx context.Context, param *icluster_conf.APIKeyTokenParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeAPIKeyStoragerForRateLimit) UpdateAPIKeyToken(ctx context.Context, filter *icluster_conf.APIKeyTokenFilter, param *icluster_conf.APIKeyTokenParam) error {
+	return nil
+}
+
+func (f *fakeAPIKeyStoragerForRateLimit) FetchAPIKeyTokenList(ctx context.Context, filter *icluster_conf.APIKeyTokenFilter) ([]*icluster_conf.APIKeyTokenParam, error) {
+	return nil, nil
+}
+
+type fakeEntityStoragerForRateLimit struct{}
+
+func (f *fakeEntityStoragerForRateLimit) CreateEntity(ctx context.Context, param *quota.EntityParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeEntityStoragerForRateLimit) FetchEntity(ctx context.Context, filter *quota.EntityFilter) (*quota.EntityParam, error) {
+	return nil, nil
+}
+
+func (f *fakeEntityStoragerForRateLimit) FetchEntityList(ctx context.Context, filter *quota.EntityFilter) ([]*quota.EntityParam, error) {
+	return nil, nil
+}
+
+func (f *fakeEntityStoragerForRateLimit) UpdateEntity(ctx context.Context, filter *quota.EntityFilter, param *quota.EntityParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeEntityStoragerForRateLimit) DeleteEntity(ctx context.Context, filter *quota.EntityFilter) error {
+	return nil
+}
+
+func setupRateLimitPolicyManager(version string) func() {
+	old := container.RateLimitPolicyManager
+	container.RateLimitPolicyManager = quota.NewRateLimitPolicyManager(
+		&testutil.FakeTxn{},
+		&fakeRateLimitPolicyStorager{},
+		&fakeAPIKeyStoragerForRateLimit{},
+		&fakeEntityStoragerForRateLimit{},
+		testutil.NewVersionControlManager(version),
+	)
+	return func() {
+		container.RateLimitPolicyManager = old
+	}
+}
+
+func TestExportAction(t *testing.T) {
+	defer setupRateLimitPolicyManager("v2")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/rate-limit-policy?version=", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*quota.ExportRateLimitPolicyConfig)
+	require.True(t, ok)
+	assert.Equal(t, "v2", conf.Version)
+	assert.Contains(t, conf.Config, "AI_product")
+}
+
+func TestExportAction_VersionNotChanged(t *testing.T) {
+	defer setupRateLimitPolicyManager("v1")()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/rate-limit-policy?version=v1", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}

--- a/endpoints/innerapi_v1/server_data/common_test.go
+++ b/endpoints/innerapi_v1/server_data/common_test.go
@@ -1,0 +1,159 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_data
+
+import (
+	"context"
+
+	"github.com/yf-networks/ai-gateway-api/endpoints/innerapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/lib"
+	"github.com/yf-networks/ai-gateway-api/model/ibasic"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+	"github.com/yf-networks/ai-gateway-api/model/iroute_conf"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeRouteRuleStorager struct {
+	fetchRoutRulesFn func(ctx context.Context, products []*ibasic.Product, clusters []*icluster_conf.Cluster) (map[int64]*iroute_conf.ProductRouteRule, error)
+}
+
+func (f *fakeRouteRuleStorager) UpsertProductRule(ctx context.Context, product *ibasic.Product, rule *iroute_conf.ProductRouteRule) error {
+	return nil
+}
+
+func (f *fakeRouteRuleStorager) FetchProductRule(ctx context.Context, product *ibasic.Product, clusterList []*icluster_conf.Cluster) (*iroute_conf.ProductRouteRule, error) {
+	return nil, nil
+}
+
+func (f *fakeRouteRuleStorager) FetchRoutRules(ctx context.Context, products []*ibasic.Product, clusters []*icluster_conf.Cluster) (map[int64]*iroute_conf.ProductRouteRule, error) {
+	if f.fetchRoutRulesFn != nil {
+		return f.fetchRoutRulesFn(ctx, products, clusters)
+	}
+	return nil, nil
+}
+
+type fakeDomainStorager struct {
+	fetchDomainsFn func(ctx context.Context, param *iroute_conf.DomainFilter) ([]*iroute_conf.Domain, error)
+}
+
+func (f *fakeDomainStorager) FetchDomains(ctx context.Context, param *iroute_conf.DomainFilter) ([]*iroute_conf.Domain, error) {
+	if f.fetchDomainsFn != nil {
+		return f.fetchDomainsFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (f *fakeDomainStorager) CreateDomain(ctx context.Context, product *ibasic.Product, param *iroute_conf.DomainParam) error {
+	return nil
+}
+
+func (f *fakeDomainStorager) DeleteDomain(ctx context.Context, product *ibasic.Product, domain *iroute_conf.Domain) error {
+	return nil
+}
+
+type fakeProductStoragerForRoute struct {
+	fetchProductsFn func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error)
+}
+
+func (f *fakeProductStoragerForRoute) FetchProducts(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+	if f.fetchProductsFn != nil {
+		return f.fetchProductsFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (f *fakeProductStoragerForRoute) DeleteProduct(ctx context.Context, p *ibasic.Product) error {
+	return nil
+}
+
+func (f *fakeProductStoragerForRoute) CreateProduct(ctx context.Context, p *ibasic.ProductParam) error {
+	return nil
+}
+
+func (f *fakeProductStoragerForRoute) UpdateProduct(ctx context.Context, p *ibasic.Product, newVal *ibasic.ProductParam) error {
+	return nil
+}
+
+type fakeClusterStoragerForRoute struct {
+	fetchClusterListFn func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error)
+}
+
+func (f *fakeClusterStoragerForRoute) FetchCluster(ctx context.Context, param *icluster_conf.ClusterFilter) (*icluster_conf.Cluster, error) {
+	return nil, nil
+}
+
+func (f *fakeClusterStoragerForRoute) FetchClusterList(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+	if f.fetchClusterListFn != nil {
+		return f.fetchClusterListFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (f *fakeClusterStoragerForRoute) ClusterUpdate(ctx context.Context, product *ibasic.Product, old *icluster_conf.Cluster, param *icluster_conf.ClusterParam) error {
+	return nil
+}
+
+func (f *fakeClusterStoragerForRoute) ClusterCreate(ctx context.Context, product *ibasic.Product, param *icluster_conf.ClusterParam, subClusters []*icluster_conf.SubCluster) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeClusterStoragerForRoute) ClusterDelete(ctx context.Context, product *ibasic.Product, cluster *icluster_conf.Cluster) error {
+	return nil
+}
+
+func (f *fakeClusterStoragerForRoute) BindSubCluster(ctx context.Context, cluster *icluster_conf.Cluster, appendSubClusters, unbindSubClusters []*icluster_conf.SubCluster) error {
+	return nil
+}
+
+func (f *fakeClusterStoragerForRoute) FetchLBMatrixList(ctx context.Context) (map[int64]map[string]map[string]int, error) {
+	return nil, nil
+}
+
+func newTestCluster() *icluster_conf.Cluster {
+	return &icluster_conf.Cluster{
+		Name: "cluster1",
+		Basic: &icluster_conf.ClusterBasic{
+			Protocol: lib.PString("http"),
+			Connection: &icluster_conf.ClusterBasicConnection{
+				MaxIdleConnPerRs: 2,
+			},
+			Retries: &icluster_conf.ClusterBasicRetries{},
+			Timeouts: &icluster_conf.ClusterBasicTimeouts{},
+			Buffers: &icluster_conf.ClusterBasicBuffers{},
+		},
+		StickySessions: &icluster_conf.ClusterStickySessions{},
+	}
+}
+
+func setupRouteRuleManager(
+	routeRuleStorager iroute_conf.RouteRuleStorager,
+	domainStorager iroute_conf.DomainStorager,
+	clusterStorager icluster_conf.ClusterStorager,
+	productStorager ibasic.ProductStorager,
+	version string,
+) func() {
+	old := container.RouteRuleManager
+	container.RouteRuleManager = iroute_conf.NewRouteRuleManager(
+		&testutil.FakeTxn{},
+		routeRuleStorager,
+		clusterStorager,
+		productStorager,
+		testutil.NewVersionControlManager(version),
+		domainStorager,
+	)
+	return func() {
+		container.RouteRuleManager = old
+	}
+}

--- a/endpoints/innerapi_v1/server_data/export_test.go
+++ b/endpoints/innerapi_v1/server_data/export_test.go
@@ -1,0 +1,148 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_data
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/model/ibasic"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+	"github.com/yf-networks/ai-gateway-api/model/iroute_conf"
+)
+
+func TestExportAction(t *testing.T) {
+	defer setupRouteRuleManager(
+		&fakeRouteRuleStorager{
+			fetchRoutRulesFn: func(ctx context.Context, products []*ibasic.Product, clusters []*icluster_conf.Cluster) (map[int64]*iroute_conf.ProductRouteRule, error) {
+				return map[int64]*iroute_conf.ProductRouteRule{
+					1: {},
+				}, nil
+			},
+		},
+		&fakeDomainStorager{
+			fetchDomainsFn: func(ctx context.Context, param *iroute_conf.DomainFilter) ([]*iroute_conf.Domain, error) {
+				return []*iroute_conf.Domain{
+					{ProductID: 1, Name: "example.com"},
+				}, nil
+			},
+		},
+		&fakeClusterStoragerForRoute{
+			fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+				return []*icluster_conf.Cluster{newTestCluster()}, nil
+			},
+		},
+		&fakeProductStoragerForRoute{
+			fetchProductsFn: func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+				return []*ibasic.Product{
+					{ID: 1, Name: "AI_product"},
+				}, nil
+			},
+		},
+		"v2",
+	)()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/tls_conf/server_data_conf?version=", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	conf, ok := data.(*iroute_conf.RouteRuleExportData)
+	require.True(t, ok)
+	assert.Equal(t, "v2", conf.Version)
+	assert.NotNil(t, conf.RouteTable)
+	assert.NotNil(t, conf.HostTable)
+	assert.NotNil(t, conf.ClusterConf)
+}
+
+func TestExportAction_FetchError(t *testing.T) {
+	defer setupRouteRuleManager(
+		&fakeRouteRuleStorager{
+			fetchRoutRulesFn: func(ctx context.Context, products []*ibasic.Product, clusters []*icluster_conf.Cluster) (map[int64]*iroute_conf.ProductRouteRule, error) {
+				return nil, errors.New("db error")
+			},
+		},
+		&fakeDomainStorager{
+			fetchDomainsFn: func(ctx context.Context, param *iroute_conf.DomainFilter) ([]*iroute_conf.Domain, error) {
+				return []*iroute_conf.Domain{
+					{ProductID: 1, Name: "example.com"},
+				}, nil
+			},
+		},
+		&fakeClusterStoragerForRoute{
+			fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+				return []*icluster_conf.Cluster{newTestCluster()}, nil
+			},
+		},
+		&fakeProductStoragerForRoute{
+			fetchProductsFn: func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+				return []*ibasic.Product{
+					{ID: 1, Name: "AI_product"},
+				}, nil
+			},
+		},
+		"v2",
+	)()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/tls_conf/server_data_conf?version=", nil)
+	_, err := ExportAction(req)
+
+	require.Error(t, err)
+	assert.Equal(t, "db error", err.Error())
+}
+
+func TestExportAction_VersionNotChanged(t *testing.T) {
+	defer setupRouteRuleManager(
+		&fakeRouteRuleStorager{
+			fetchRoutRulesFn: func(ctx context.Context, products []*ibasic.Product, clusters []*icluster_conf.Cluster) (map[int64]*iroute_conf.ProductRouteRule, error) {
+				return map[int64]*iroute_conf.ProductRouteRule{
+					1: {},
+				}, nil
+			},
+		},
+		&fakeDomainStorager{
+			fetchDomainsFn: func(ctx context.Context, param *iroute_conf.DomainFilter) ([]*iroute_conf.Domain, error) {
+				return []*iroute_conf.Domain{
+					{ProductID: 1, Name: "example.com"},
+				}, nil
+			},
+		},
+		&fakeClusterStoragerForRoute{
+			fetchClusterListFn: func(ctx context.Context, param *icluster_conf.ClusterFilter) ([]*icluster_conf.Cluster, error) {
+				return []*icluster_conf.Cluster{newTestCluster()}, nil
+			},
+		},
+		&fakeProductStoragerForRoute{
+			fetchProductsFn: func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+				return []*ibasic.Product{
+					{ID: 1, Name: "AI_product"},
+				}, nil
+			},
+		},
+		"v1",
+	)()
+
+	req := httptest.NewRequest(http.MethodGet, "/configs/tls_conf/server_data_conf?version=v1", nil)
+	data, err := ExportAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}

--- a/endpoints/middleware/access_logger_test.go
+++ b/endpoints/middleware/access_logger_test.go
@@ -1,0 +1,96 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/codegangsta/negroni"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/lib/xreq"
+	"github.com/yf-networks/ai-gateway-api/stateful"
+)
+
+func TestGetClientIp(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Clientip", "10.0.0.1")
+	assert.Equal(t, "10.0.0.1", GetClientIp(req))
+
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	assert.Equal(t, "", GetClientIp(req))
+}
+
+func TestUpdateMonitor(t *testing.T) {
+	labels := prometheus.Labels{
+		"pattern":     "/products",
+		"method":      "get",
+		"status_code": "200",
+	}
+	before := testutil.ToFloat64(stateful.MetricAPIAccessCounter.With(labels))
+
+	req := httptest.NewRequest(http.MethodGet, "/products", nil)
+	requestInfo := &xreq.RequestInfo{
+		URLPattern: "/products",
+		Method:     http.MethodGet,
+		StatusCode: 200,
+		Duration:   5 * time.Millisecond,
+	}
+	UpdateMonitor(req, requestInfo)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(stateful.MetricAPIAccessCounter.With(labels)))
+	assert.GreaterOrEqual(t, testutil.ToFloat64(stateful.MetricAPICostHisCounter.With(labels)), before)
+}
+
+func TestRecord(t *testing.T) {
+	setupTestLoggers(t)
+
+	// Should not panic for either success or failure status codes.
+	Record(&xreq.RequestInfo{StatusCode: 200})
+	Record(&xreq.RequestInfo{StatusCode: 500})
+	Record(&xreq.RequestInfo{StatusCode: 404})
+}
+
+func TestLoggerMiddleWare_ServeHTTP(t *testing.T) {
+	setupTestLoggers(t)
+
+	lm := NewLoggerMiddleWare()
+	req := httptest.NewRequest(http.MethodGet, "/products", nil)
+	ctx, requestInfo := xreq.InitRequestInfo(req.Context(), req)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	nrw := negroni.NewResponseWriter(rec)
+
+	called := false
+	lm.ServeHTTP(nrw, req, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusCreated, requestInfo.StatusCode)
+	assert.GreaterOrEqual(t, requestInfo.Duration.Nanoseconds(), int64(0))
+}
+
+func TestNewLoggerMiddleWare(t *testing.T) {
+	lm := NewLoggerMiddleWare()
+	require.NotNil(t, lm)
+}

--- a/endpoints/middleware/common_test.go
+++ b/endpoints/middleware/common_test.go
@@ -1,0 +1,59 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/baidu/go-lib/log/log4go"
+	"github.com/yf-networks/ai-gateway-api/model/itxn"
+	"github.com/yf-networks/ai-gateway-api/stateful"
+)
+
+// fakeTxn is a no-op transaction storager used by unit tests that need to
+// build real manager instances.
+type fakeTxn struct{}
+
+func (f *fakeTxn) AtomExecute(ctx context.Context, do func(context.Context) error) error {
+	return do(ctx)
+}
+
+var _ itxn.TxnStorager = (*fakeTxn)(nil)
+
+// setupTestLoggers initializes global loggers with console output so that
+// middleware which depends on them (recovery, access logger) can run in tests
+// without writing to real log files. The original loggers are restored in the
+// cleanup callback.
+func setupTestLoggers(t *testing.T) {
+	t.Helper()
+
+	origAccess := stateful.AccessLogger
+	origException := stateful.ExceptionLogger
+
+	stateful.AccessLogger = log4go.NewDefaultLogger(log4go.DEBUG)
+	stateful.ExceptionLogger = log4go.NewDefaultLogger(log4go.DEBUG)
+
+	t.Cleanup(func() {
+		if stateful.AccessLogger != nil {
+			stateful.AccessLogger.Close()
+		}
+		if stateful.ExceptionLogger != nil {
+			stateful.ExceptionLogger.Close()
+		}
+		stateful.AccessLogger = origAccess
+		stateful.ExceptionLogger = origException
+	})
+}

--- a/endpoints/middleware/convert_test.go
+++ b/endpoints/middleware/convert_test.go
@@ -1,0 +1,77 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvert_Success(t *testing.T) {
+	called := false
+	handler := func(req *http.Request) (*http.Request, error) {
+		called = true
+		return req, nil
+	}
+
+	mw := convert(handler)
+	require.NotNil(t, mw)
+
+	router := mux.NewRouter()
+	router.Use(mw)
+	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods(http.MethodGet)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rw := httptest.NewRecorder()
+	router.ServeHTTP(rw, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rw.Code)
+}
+
+func TestConvert_Error(t *testing.T) {
+	handler := func(req *http.Request) (*http.Request, error) {
+		return nil, errors.New("convert failed")
+	}
+
+	mw := convert(handler)
+	require.NotNil(t, mw)
+
+	router := mux.NewRouter()
+	router.Use(mw)
+	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods(http.MethodGet)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rw := httptest.NewRecorder()
+	router.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rw.Code)
+	assert.Contains(t, rw.Body.String(), "convert failed")
+}
+
+func TestMiddlewareVariables(t *testing.T) {
+	assert.NotNil(t, McProductProbe)
+	assert.NotNil(t, McUserProbe)
+}

--- a/endpoints/middleware/cors_test.go
+++ b/endpoints/middleware/cors_test.go
@@ -1,0 +1,58 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCors(t *testing.T) {
+	c := NewCors()
+	require.NotNil(t, c)
+
+	handler := c.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+	}))
+
+	// Preflight request
+	req := httptest.NewRequest(http.MethodOptions, "/resource", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "Authorization")
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusNoContent, rw.Code)
+	assert.Equal(t, "*", rw.Header().Get("Access-Control-Allow-Origin"))
+	assert.NotEmpty(t, rw.Header().Get("Access-Control-Allow-Methods"))
+	assert.Contains(t, rw.Header().Get("Access-Control-Allow-Headers"), "Authorization")
+	assert.Equal(t, "true", rw.Header().Get("Access-Control-Allow-Credentials"))
+
+	// Actual cross-origin request
+	req = httptest.NewRequest(http.MethodGet, "/resource", nil)
+	req.Header.Set("Origin", "https://example.com")
+	rw = httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Equal(t, "hello", rw.Body.String())
+	assert.Equal(t, "*", rw.Header().Get("Access-Control-Allow-Origin"))
+}

--- a/endpoints/middleware/product_probe_test.go
+++ b/endpoints/middleware/product_probe_test.go
@@ -1,0 +1,228 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/model/ibasic"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeProductStorager struct {
+	fetchProductsFn func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error)
+	deleteProductFn func(ctx context.Context, p *ibasic.Product) error
+	createProductFn func(ctx context.Context, p *ibasic.ProductParam) error
+	updateProductFn func(ctx context.Context, p *ibasic.Product, newVal *ibasic.ProductParam) error
+}
+
+func (f *fakeProductStorager) FetchProducts(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+	if f.fetchProductsFn != nil {
+		return f.fetchProductsFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (f *fakeProductStorager) DeleteProduct(ctx context.Context, p *ibasic.Product) error {
+	if f.deleteProductFn != nil {
+		return f.deleteProductFn(ctx, p)
+	}
+	return nil
+}
+
+func (f *fakeProductStorager) CreateProduct(ctx context.Context, p *ibasic.ProductParam) error {
+	if f.createProductFn != nil {
+		return f.createProductFn(ctx, p)
+	}
+	return nil
+}
+
+func (f *fakeProductStorager) UpdateProduct(ctx context.Context, p *ibasic.Product, newVal *ibasic.ProductParam) error {
+	if f.updateProductFn != nil {
+		return f.updateProductFn(ctx, p, newVal)
+	}
+	return nil
+}
+
+func setProductManager(storager ibasic.ProductStorager) func() {
+	old := container.ProductManager
+	container.ProductManager = ibasic.NewProductManager(&fakeTxn{}, storager)
+	return func() {
+		container.ProductManager = old
+	}
+}
+
+func TestProductProbeAction_NoParam(t *testing.T) {
+	defer setProductManager(&fakeProductStorager{})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products", nil)
+	newReq, err := ProductProbeAction(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, req, newReq)
+}
+
+func TestProductProbeAction_SuccessByID(t *testing.T) {
+	expected := &ibasic.Product{ID: 2, Name: "demo"}
+	defer setProductManager(&fakeProductStorager{
+		fetchProductsFn: func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+			require.NotNil(t, param.ID)
+			assert.Equal(t, int64(2), *param.ID)
+			return []*ibasic.Product{expected}, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products/2", nil)
+	req = mux.SetURLVars(req, map[string]string{"product_id": "2"})
+	newReq, err := ProductProbeAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, newReq)
+
+	product, err := ibasic.MustGetProduct(newReq.Context())
+	require.NoError(t, err)
+	assert.Equal(t, expected, product)
+}
+
+func TestProductProbeAction_SuccessByName(t *testing.T) {
+	expected := &ibasic.Product{ID: 3, Name: "ai-product"}
+	defer setProductManager(&fakeProductStorager{
+		fetchProductsFn: func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+			require.NotNil(t, param.Name)
+			assert.Equal(t, "ai-product", *param.Name)
+			return []*ibasic.Product{expected}, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products/ai-product", nil)
+	req = mux.SetURLVars(req, map[string]string{"product_name": "ai-product"})
+	newReq, err := ProductProbeAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, newReq)
+
+	product, err := ibasic.MustGetProduct(newReq.Context())
+	require.NoError(t, err)
+	assert.Equal(t, expected, product)
+}
+
+func TestProductProbeAction_MultipleProducts(t *testing.T) {
+	defer setProductManager(&fakeProductStorager{
+		fetchProductsFn: func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+			return []*ibasic.Product{
+				{ID: 1, Name: "a"},
+				{ID: 2, Name: "b"},
+			}, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products/1", nil)
+	req = mux.SetURLVars(req, map[string]string{"product_id": "1"})
+	newReq, err := ProductProbeAction(req)
+
+	require.Error(t, err)
+	assert.Nil(t, newReq)
+	assert.Contains(t, err.Error(), "Product Record Not Exist")
+}
+
+func TestProductProbeAction_NotFound(t *testing.T) {
+	defer setProductManager(&fakeProductStorager{
+		fetchProductsFn: func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+			return nil, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products/999", nil)
+	req = mux.SetURLVars(req, map[string]string{"product_id": "999"})
+	newReq, err := ProductProbeAction(req)
+
+	require.Error(t, err)
+	assert.Nil(t, newReq)
+	assert.Contains(t, err.Error(), "Product Record Not Exist")
+}
+
+func TestProductProbeAction_FetchError(t *testing.T) {
+	defer setProductManager(&fakeProductStorager{
+		fetchProductsFn: func(ctx context.Context, param *ibasic.ProductFilter) ([]*ibasic.Product, error) {
+			return nil, errors.New("database down")
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products/1", nil)
+	req = mux.SetURLVars(req, map[string]string{"product_id": "1"})
+	newReq, err := ProductProbeAction(req)
+
+	require.Error(t, err)
+	assert.Nil(t, newReq)
+	assert.Equal(t, "database down", err.Error())
+}
+
+func TestProductProbeAction_BindURIError(t *testing.T) {
+	defer setProductManager(&fakeProductStorager{})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products/abc", nil)
+	req = mux.SetURLVars(req, map[string]string{"product_id": "abc"})
+	newReq, err := ProductProbeAction(req)
+
+	require.Error(t, err)
+	assert.Nil(t, newReq)
+}
+
+func TestNewMiddleWareFunc_Success(t *testing.T) {
+	called := false
+	handler := func(req *http.Request) (*http.Request, error) {
+		called = true
+		return req, nil
+	}
+
+	mw := NewMiddleWareFunc(handler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rw := httptest.NewRecorder()
+
+	nextCalled := false
+	mw(rw, req, func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		assert.Equal(t, req, r)
+	})
+
+	assert.True(t, called)
+	assert.True(t, nextCalled)
+}
+
+func TestNewMiddleWareFunc_Error(t *testing.T) {
+	handler := func(req *http.Request) (*http.Request, error) {
+		return nil, errors.New("probe failed")
+	}
+
+	mw := NewMiddleWareFunc(handler)
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rw := httptest.NewRecorder()
+
+	nextCalled := false
+	mw(rw, req, func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+	})
+
+	assert.False(t, nextCalled)
+	assert.Equal(t, http.StatusInternalServerError, rw.Code)
+	assert.Contains(t, rw.Body.String(), "probe failed")
+}

--- a/endpoints/middleware/recovery_test.go
+++ b/endpoints/middleware/recovery_test.go
@@ -1,0 +1,88 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRecovery(t *testing.T) {
+	rec := NewRecovery()
+	require.NotNil(t, rec)
+	assert.False(t, rec.StackAll)
+	assert.Equal(t, 1024*8, rec.StackSize)
+}
+
+func TestRecovery_ServeHTTP_Normal(t *testing.T) {
+	setupTestLoggers(t)
+
+	rec := NewRecovery()
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	rw := httptest.NewRecorder()
+
+	called := false
+	rec.ServeHTTP(rw, req, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Equal(t, "ok", rw.Body.String())
+}
+
+func TestRecovery_ServeHTTP_Panic(t *testing.T) {
+	setupTestLoggers(t)
+
+	rec := NewRecovery()
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	rw := httptest.NewRecorder()
+
+	rec.ServeHTTP(rw, req, func(w http.ResponseWriter, r *http.Request) {
+		panic("something terrible")
+	})
+
+	assert.Equal(t, http.StatusInternalServerError, rw.Code)
+	assert.Contains(t, rw.Body.String(), "system error")
+	assert.Equal(t, "application/json", rw.Header().Get("Content-Type"))
+}
+
+func TestMcConvert(t *testing.T) {
+	setupTestLoggers(t)
+
+	handler := NewRecovery()
+	middleware := McConvert(handler)
+	require.NotNil(t, middleware)
+
+	router := mux.NewRouter()
+	router.Use(middleware)
+	router.HandleFunc("/panic", func(w http.ResponseWriter, r *http.Request) {
+		panic("router panic")
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	rw := httptest.NewRecorder()
+	router.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rw.Code)
+	assert.Contains(t, rw.Body.String(), "system error")
+}

--- a/endpoints/middleware/user_probe_test.go
+++ b/endpoints/middleware/user_probe_test.go
@@ -1,0 +1,221 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/model/iauth"
+	"github.com/yf-networks/ai-gateway-api/model/ibasic"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeAuthenticateStorager struct {
+	fetchUserListFn func(ctx context.Context, param *iauth.UserFilter) ([]*iauth.User, error)
+	fetchUserFn     func(ctx context.Context, param *iauth.UserFilter) (*iauth.User, error)
+	updateUserFn    func(ctx context.Context, user *iauth.User, param *iauth.UserParam) error
+	createUserFn    func(ctx context.Context, param *iauth.UserParam) error
+	deleteUserFn    func(ctx context.Context, user *iauth.User) error
+	fetchTokensFn   func(ctx context.Context, param *iauth.TokenFilter) ([]*iauth.Token, error)
+	createTokenFn   func(ctx context.Context, token *iauth.TokenParam) error
+	deleteTokenFn   func(ctx context.Context, param *iauth.Token) error
+}
+
+func (s *fakeAuthenticateStorager) FetchUserList(ctx context.Context, param *iauth.UserFilter) ([]*iauth.User, error) {
+	if s.fetchUserListFn != nil {
+		return s.fetchUserListFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (s *fakeAuthenticateStorager) FetchUser(ctx context.Context, param *iauth.UserFilter) (*iauth.User, error) {
+	if s.fetchUserFn != nil {
+		return s.fetchUserFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (s *fakeAuthenticateStorager) UpdateUser(ctx context.Context, user *iauth.User, param *iauth.UserParam) error {
+	if s.updateUserFn != nil {
+		return s.updateUserFn(ctx, user, param)
+	}
+	return nil
+}
+
+func (s *fakeAuthenticateStorager) CreateUser(ctx context.Context, param *iauth.UserParam) error {
+	if s.createUserFn != nil {
+		return s.createUserFn(ctx, param)
+	}
+	return nil
+}
+
+func (s *fakeAuthenticateStorager) DeleteUser(ctx context.Context, user *iauth.User) error {
+	if s.deleteUserFn != nil {
+		return s.deleteUserFn(ctx, user)
+	}
+	return nil
+}
+
+func (s *fakeAuthenticateStorager) FetchTokens(ctx context.Context, param *iauth.TokenFilter) ([]*iauth.Token, error) {
+	if s.fetchTokensFn != nil {
+		return s.fetchTokensFn(ctx, param)
+	}
+	return nil, nil
+}
+
+func (s *fakeAuthenticateStorager) CreateToken(ctx context.Context, token *iauth.TokenParam) error {
+	if s.createTokenFn != nil {
+		return s.createTokenFn(ctx, token)
+	}
+	return nil
+}
+
+func (s *fakeAuthenticateStorager) DeleteToken(ctx context.Context, param *iauth.Token) error {
+	if s.deleteTokenFn != nil {
+		return s.deleteTokenFn(ctx, param)
+	}
+	return nil
+}
+
+type fakeAuthorizeStorager struct{}
+
+func (s *fakeAuthorizeStorager) UnbindUserProduct(ctx context.Context, user *iauth.User, product *ibasic.Product) error {
+	return nil
+}
+
+func (s *fakeAuthorizeStorager) UnbindUserAllProduct(ctx context.Context, user *iauth.User) error {
+	return nil
+}
+
+func (s *fakeAuthorizeStorager) BindUserProduct(ctx context.Context, user *iauth.User, product *ibasic.Product) error {
+	return nil
+}
+
+func (s *fakeAuthorizeStorager) FetchUserProducts(ctx context.Context, user *iauth.User) ([]*ibasic.Product, error) {
+	return nil, nil
+}
+
+func (s *fakeAuthorizeStorager) FetchProductUsers(ctx context.Context, product *ibasic.Product) ([]*iauth.User, error) {
+	return nil, nil
+}
+
+func (s *fakeAuthorizeStorager) UpdateUserScopes(ctx context.Context, user *iauth.User, scopes []string) error {
+	return nil
+}
+
+func (s *fakeAuthorizeStorager) IsUserProductGranted(ctx context.Context, user *iauth.User, product *ibasic.Product) (bool, error) {
+	return false, nil
+}
+
+func (s *fakeAuthorizeStorager) UnbindTokenAllProduct(ctx context.Context, token *iauth.Token) error {
+	return nil
+}
+
+func (s *fakeAuthorizeStorager) BindTokenProduct(ctx context.Context, token *iauth.Token, product *ibasic.Product) error {
+	return nil
+}
+
+func (s *fakeAuthorizeStorager) FetchProductTokens(ctx context.Context, product *ibasic.Product) ([]*iauth.Token, error) {
+	return nil, nil
+}
+
+func (s *fakeAuthorizeStorager) IsTokenProductGranted(ctx context.Context, token *iauth.Token, product *ibasic.Product) (bool, error) {
+	return false, nil
+}
+
+func (s *fakeAuthorizeStorager) FetchTokenProduct(ctx context.Context, token *iauth.Token) (*ibasic.Product, error) {
+	return nil, nil
+}
+
+func (s *fakeAuthorizeStorager) BatchFetchTokenProduct(ctx context.Context, token []*iauth.Token) (map[int64]*ibasic.Product, error) {
+	return nil, nil
+}
+
+func setAuthenticateManager(storager iauth.AuthenticateStorager) func() {
+	old := container.AuthenticateManager
+	container.AuthenticateManager = iauth.NewAuthenticateManager(&fakeTxn{}, storager, &fakeAuthorizeStorager{})
+	return func() {
+		container.AuthenticateManager = old
+	}
+}
+
+
+func TestUserProbeAction_NoAuthorization(t *testing.T) {
+	defer setAuthenticateManager(&fakeAuthenticateStorager{})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products", nil)
+	newReq, err := UserProbeAction(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, req, newReq)
+}
+
+func TestUserProbeAction_BadFormat(t *testing.T) {
+	defer setAuthenticateManager(&fakeAuthenticateStorager{})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products", nil)
+	req.Header.Set("Authorization", "OnlyOnePart")
+	newReq, err := UserProbeAction(req)
+
+	require.Error(t, err)
+	assert.Nil(t, newReq)
+	assert.Contains(t, err.Error(), "Bad Format Header Authorization")
+}
+
+func TestUserProbeAction_AuthenticateFail(t *testing.T) {
+	defer setAuthenticateManager(&fakeAuthenticateStorager{
+		fetchTokensFn: func(ctx context.Context, param *iauth.TokenFilter) ([]*iauth.Token, error) {
+			return nil, errors.New("auth failed")
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products", nil)
+	req.Header.Set("Authorization", "Token fake-token")
+	newReq, err := UserProbeAction(req)
+
+	require.Error(t, err)
+	assert.Nil(t, newReq)
+	assert.Equal(t, "auth failed", err.Error())
+}
+
+func TestUserProbeAction_Success(t *testing.T) {
+	expected := &iauth.Visitor{
+		Token: &iauth.Token{ID: 1, Name: "token-user", Token: "fake-token"},
+	}
+	defer setAuthenticateManager(&fakeAuthenticateStorager{
+		fetchTokensFn: func(ctx context.Context, param *iauth.TokenFilter) ([]*iauth.Token, error) {
+			require.NotNil(t, param.Token)
+			assert.Equal(t, "fake-token", *param.Token)
+			return []*iauth.Token{expected.Token}, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/products", nil)
+	req.Header.Set("Authorization", "Token fake-token")
+	newReq, err := UserProbeAction(req)
+
+	require.NoError(t, err)
+	require.NotNil(t, newReq)
+
+	visitor, err := iauth.MustGetVisitor(newReq.Context())
+	require.NoError(t, err)
+	assert.Equal(t, expected.Token, visitor.Token)
+}

--- a/endpoints/openapi_v1/bfe_pool/endpoints_test.go
+++ b/endpoints/openapi_v1/bfe_pool/endpoints_test.go
@@ -1,0 +1,31 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bfe_pool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 2)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+}

--- a/endpoints/openapi_v1/certificate/endpoints_test.go
+++ b/endpoints/openapi_v1/certificate/endpoints_test.go
@@ -1,0 +1,31 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 5)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+}

--- a/endpoints/openapi_v1/endpoints.go
+++ b/endpoints/openapi_v1/endpoints.go
@@ -66,7 +66,7 @@ func endpoints() []*xreq.Endpoint {
 		entity.Endpoints,
 		global_route_rules.Endpoints,
 		route_tables.Endpoints,
-		model_provider_type.Endpoints,
+		model_provider_type.NewEndpoints(nil),
 		tool.Endpoints,
 	)
 }

--- a/endpoints/openapi_v1/endpoints_test.go
+++ b/endpoints/openapi_v1/endpoints_test.go
@@ -1,0 +1,58 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi_v1
+
+import (
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoints(t *testing.T) {
+	eps := endpoints()
+	require.NotEmpty(t, eps)
+
+	paths := make(map[string]bool)
+	for _, ep := range eps {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+		paths[ep.Path] = true
+	}
+
+	// Sanity check that some well-known paths are registered.
+	assert.Contains(t, paths, "/auth/users")
+	assert.Contains(t, paths, "/clusters")
+}
+
+func TestRegisterEndpoints(t *testing.T) {
+	root := mux.NewRouter()
+	sub := RegisterEndpoints(root)
+
+	require.NotNil(t, sub)
+
+	var matchedPaths []string
+	err := sub.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
+		path, err := route.GetPathTemplate()
+		if err == nil {
+			matchedPaths = append(matchedPaths, path)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, matchedPaths)
+}

--- a/endpoints/openapi_v1/entity_type/endpoints_test.go
+++ b/endpoints/openapi_v1/entity_type/endpoints_test.go
@@ -1,0 +1,31 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entity_type
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 5)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+}

--- a/endpoints/openapi_v1/general/endpoints_test.go
+++ b/endpoints/openapi_v1/general/endpoints_test.go
@@ -1,0 +1,31 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package general
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 1)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+}

--- a/endpoints/openapi_v1/global_route_rules/endpoints_test.go
+++ b/endpoints/openapi_v1/global_route_rules/endpoints_test.go
@@ -1,0 +1,211 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package global_route_rules
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/endpoints/openapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/lib"
+	"github.com/yf-networks/ai-gateway-api/model/shared"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeRouteRulesStorager struct {
+	fetchRouteRulesFn   func(ctx context.Context, ruleType string, owner *string) (*shared.RouteRulesParam, error)
+	createRouteRulesFn  func(ctx context.Context, ruleType string, owner *string, param *shared.RouteRulesParam) (int64, error)
+	updateRouteRulesFn  func(ctx context.Context, id int64, param *shared.RouteRulesParam) (int64, error)
+	fetchRouteRulesByID func(ctx context.Context, id int64) (*shared.RouteRulesParam, error)
+}
+
+func (f *fakeRouteRulesStorager) CreateRouteRules(ctx context.Context, ruleType string, owner *string, param *shared.RouteRulesParam) (int64, error) {
+	if f.createRouteRulesFn != nil {
+		return f.createRouteRulesFn(ctx, ruleType, owner, param)
+	}
+	return 1, nil
+}
+
+func (f *fakeRouteRulesStorager) FetchRouteRules(ctx context.Context, ruleType string, owner *string) (*shared.RouteRulesParam, error) {
+	if f.fetchRouteRulesFn != nil {
+		return f.fetchRouteRulesFn(ctx, ruleType, owner)
+	}
+	return nil, nil
+}
+
+func (f *fakeRouteRulesStorager) FetchRouteRulesList(ctx context.Context, filter *shared.RouteRulesFilter) ([]*shared.RouteTableParam, int64, error) {
+	return nil, 0, nil
+}
+
+func (f *fakeRouteRulesStorager) UpdateRouteRules(ctx context.Context, id int64, param *shared.RouteRulesParam) (int64, error) {
+	if f.updateRouteRulesFn != nil {
+		return f.updateRouteRulesFn(ctx, id, param)
+	}
+	return id, nil
+}
+
+func (f *fakeRouteRulesStorager) DeleteRouteRules(ctx context.Context, id int64) error {
+	return nil
+}
+
+func (f *fakeRouteRulesStorager) FetchRouteRulesByID(ctx context.Context, id int64) (*shared.RouteRulesParam, error) {
+	if f.fetchRouteRulesByID != nil {
+		return f.fetchRouteRulesByID(ctx, id)
+	}
+	return nil, nil
+}
+
+func setupRouteRulesManager(storager shared.RouteRulesStorager) func() {
+	old := container.RouteRulesManager
+	container.RouteRulesManager = shared.NewRouteRulesManager(&testutil.FakeTxn{}, storager)
+	return func() {
+		container.RouteRulesManager = old
+	}
+}
+
+func validRouteRulesParam() *shared.RouteRulesParam {
+	enabled := true
+	weight := 100
+	return &shared.RouteRulesParam{
+		Enabled: &enabled,
+		Rules: []*shared.AiRouteRuleParam{
+			{
+				Name: lib.PString("rule1"),
+				Cond: lib.PString("default_t()"),
+				Targets: []*shared.AiRouteTargetParam{
+					{ClusterName: lib.PString("cluster1"), Weight: &weight},
+				},
+			},
+		},
+	}
+}
+
+func TestGlobalRouteRulesGetAction(t *testing.T) {
+	expected := validRouteRulesParam()
+	expected.ID = lib.PInt64(1)
+	defer setupRouteRulesManager(&fakeRouteRulesStorager{
+		fetchRouteRulesFn: func(ctx context.Context, ruleType string, owner *string) (*shared.RouteRulesParam, error) {
+			assert.Equal(t, shared.RouteRulesTypeGlobal, ruleType)
+			return expected, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/global-route-rules", nil)
+	data, err := GlobalRouteRulesGetAction(req)
+
+	require.NoError(t, err)
+	result, ok := data.(*shared.RouteRulesParam)
+	require.True(t, ok)
+	assert.Nil(t, result.ID)
+	assert.Equal(t, expected.Rules[0].Name, result.Rules[0].Name)
+}
+
+func TestGlobalRouteRulesGetAction_NotFound(t *testing.T) {
+	defer setupRouteRulesManager(&fakeRouteRulesStorager{
+		fetchRouteRulesFn: func(ctx context.Context, ruleType string, owner *string) (*shared.RouteRulesParam, error) {
+			return nil, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/global-route-rules", nil)
+	data, err := GlobalRouteRulesGetAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}
+
+func TestGlobalRouteRulesUpdateAction(t *testing.T) {
+	updated := validRouteRulesParam()
+	updated.ID = lib.PInt64(1)
+	defer setupRouteRulesManager(&fakeRouteRulesStorager{
+		fetchRouteRulesFn: func(ctx context.Context, ruleType string, owner *string) (*shared.RouteRulesParam, error) {
+			return &shared.RouteRulesParam{ID: lib.PInt64(1)}, nil
+		},
+		updateRouteRulesFn: func(ctx context.Context, id int64, param *shared.RouteRulesParam) (int64, error) {
+			assert.Equal(t, int64(1), id)
+			return id, nil
+		},
+		fetchRouteRulesByID: func(ctx context.Context, id int64) (*shared.RouteRulesParam, error) {
+			return updated, nil
+		},
+	})()
+
+	body := `{
+		"enabled": true,
+		"rules": [
+			{
+				"name": "rule1",
+				"Cond": "default_t()",
+				"targets": [
+					{"ClusterName": "cluster1", "Weight": 100}
+				]
+			}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/global-route-rules", strings.NewReader(body))
+	data, err := GlobalRouteRulesUpdateAction(req)
+
+	require.NoError(t, err)
+	result, ok := data.(*shared.RouteRulesParam)
+	require.True(t, ok)
+	assert.Nil(t, result.ID)
+	assert.Len(t, result.Rules, 1)
+}
+
+func TestGlobalRouteRulesUpdateAction_InvalidJSON(t *testing.T) {
+	defer setupRouteRulesManager(&fakeRouteRulesStorager{})()
+
+	req := httptest.NewRequest(http.MethodPut, "/global-route-rules", strings.NewReader("not-json"))
+	_, err := GlobalRouteRulesUpdateAction(req)
+
+	require.Error(t, err)
+}
+
+func TestGlobalRouteRulesUpdateAction_NotFound(t *testing.T) {
+	defer setupRouteRulesManager(&fakeRouteRulesStorager{
+		fetchRouteRulesFn: func(ctx context.Context, ruleType string, owner *string) (*shared.RouteRulesParam, error) {
+			return &shared.RouteRulesParam{ID: lib.PInt64(1)}, nil
+		},
+		updateRouteRulesFn: func(ctx context.Context, id int64, param *shared.RouteRulesParam) (int64, error) {
+			return id, nil
+		},
+		fetchRouteRulesByID: func(ctx context.Context, id int64) (*shared.RouteRulesParam, error) {
+			return nil, nil
+		},
+	})()
+
+	body := `{
+		"enabled": true,
+		"rules": [
+			{
+				"name": "rule1",
+				"Cond": "default_t()",
+				"targets": [
+					{"ClusterName": "cluster1", "Weight": 100}
+				]
+			}
+		]
+	}`
+	req := httptest.NewRequest(http.MethodPut, "/global-route-rules", strings.NewReader(body))
+	_, err := GlobalRouteRulesUpdateAction(req)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Record Not Exist")
+}

--- a/endpoints/openapi_v1/internal/testutil/testutil.go
+++ b/endpoints/openapi_v1/internal/testutil/testutil.go
@@ -1,0 +1,30 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"context"
+
+	"github.com/yf-networks/ai-gateway-api/model/itxn"
+)
+
+// FakeTxn is a no-op transaction storager used by unit tests.
+type FakeTxn struct{}
+
+func (f *FakeTxn) AtomExecute(ctx context.Context, do func(context.Context) error) error {
+	return do(ctx)
+}
+
+var _ itxn.TxnStorager = (*FakeTxn)(nil)

--- a/endpoints/openapi_v1/model_provider_type/endpoints.go
+++ b/endpoints/openapi_v1/model_provider_type/endpoints.go
@@ -1,16 +1,16 @@
 // Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
 //
-//Licensed under the Apache License, Version 2.0 (the "License");
-//you may not use this file except in compliance with the License.
-//You may obtain a copy of the License at
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//http: //www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-//Unless required by applicable law or agreed to in writing, software
-//distributed under the License is distributed on an "AS IS" BASIS,
-//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//See the License for the specific language governing permissions and
-//limitations under the License.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package model_provider_type
 
@@ -26,17 +26,37 @@ import (
 	"github.com/yf-networks/ai-gateway-api/model/iauth"
 )
 
-var _ xreq.Handler = ListModelProviderTypesAction
+const DefaultModelProviderConfigPath = "conf/ai/models.json"
 
-var ListModelProviderTypesRoute = &xreq.Endpoint{
-	Path:       "/model-provider-types",
-	Method:     http.MethodGet,
-	Handler:    xreq.Convert(ListModelProviderTypesAction),
-	Authorizer: iauth.FA(iauth.FeatureProductCluster, iauth.ActionRead),
+// modelProviderConfigReader abstracts the config source so tests can inject
+// fake readers without touching the file system.
+type modelProviderConfigReader func() ([]byte, error)
+
+// DefaultModelProviderConfigReader returns a reader that loads the provider
+// type configuration from the default file path.
+func DefaultModelProviderConfigReader() modelProviderConfigReader {
+	return func() ([]byte, error) {
+		return os.ReadFile(DefaultModelProviderConfigPath)
+	}
 }
 
-var Endpoints = []*xreq.Endpoint{
-	ListModelProviderTypesRoute,
+// NewEndpoints creates the model-provider-types endpoints using the given
+// config reader. Passing nil falls back to the default file-based reader.
+func NewEndpoints(reader modelProviderConfigReader) []*xreq.Endpoint {
+	if reader == nil {
+		reader = DefaultModelProviderConfigReader()
+	}
+
+	action := func(req *http.Request) (interface{}, error) {
+		return listModelProviderTypesProcess(req.Context(), reader)
+	}
+
+	return []*xreq.Endpoint{{
+		Path:       "/model-provider-types",
+		Method:     http.MethodGet,
+		Handler:    xreq.Convert(action),
+		Authorizer: iauth.FA(iauth.FeatureProductCluster, iauth.ActionRead),
+	}}
 }
 
 type ModelProvider struct {
@@ -44,19 +64,15 @@ type ModelProvider struct {
 	ID   string `json:"id"`
 }
 
-func ListModelProviderTypesAction(req *http.Request) (interface{}, error) {
-	return listModelProviderTypesProcess(req.Context())
-}
-
-func listModelProviderTypesProcess(ctx context.Context) (interface{}, error) {
-	data, err := os.ReadFile("conf/ai/models.json")
+func listModelProviderTypesProcess(ctx context.Context, reader modelProviderConfigReader) (interface{}, error) {
+	data, err := reader()
 	if err != nil {
-		return nil, xerror.WrapParamError(fmt.Errorf("failed to read config conf/ai/models.json: %w", err))
+		return nil, xerror.WrapParamError(fmt.Errorf("failed to read config %s: %w", DefaultModelProviderConfigPath, err))
 	}
 
 	var providers []ModelProvider
 	if err := json.Unmarshal(data, &providers); err != nil {
-		return nil, xerror.WrapParamError(fmt.Errorf("failed to parse config conf/ai/models.json: %w", err))
+		return nil, xerror.WrapParamError(fmt.Errorf("failed to parse config %s: %w", DefaultModelProviderConfigPath, err))
 	}
 
 	types := make([]string, 0, len(providers))

--- a/endpoints/openapi_v1/model_provider_type/endpoints_test.go
+++ b/endpoints/openapi_v1/model_provider_type/endpoints_test.go
@@ -1,0 +1,81 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model_provider_type
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListModelProviderTypesAction_FileNotExist(t *testing.T) {
+	reader := func() ([]byte, error) {
+		return nil, errors.New("no such file")
+	}
+
+	_, err := listModelProviderTypesProcess(context.Background(), reader)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "models.json")
+}
+
+func TestListModelProviderTypesAction_Success(t *testing.T) {
+	content := `[{"name": "OpenAI", "id": "openai"}, {"name": "Empty", "id": ""}]`
+	reader := func() ([]byte, error) {
+		return []byte(content), nil
+	}
+
+	data, err := listModelProviderTypesProcess(context.Background(), reader)
+	require.NoError(t, err)
+	types, ok := data.([]string)
+	require.True(t, ok)
+	assert.Equal(t, []string{"openai"}, types)
+}
+
+func TestListModelProviderTypesAction_InvalidJSON(t *testing.T) {
+	reader := func() ([]byte, error) {
+		return []byte("not-json"), nil
+	}
+
+	_, err := listModelProviderTypesProcess(context.Background(), reader)
+	require.Error(t, err)
+}
+
+func TestEndpoints(t *testing.T) {
+	reader := func() ([]byte, error) {
+		return []byte(`[{"name": "OpenAI", "id": "openai"}, {"name": "Azure", "id": "azure"}]`), nil
+	}
+
+	endpoints := NewEndpoints(reader)
+	require.Len(t, endpoints, 1)
+	ep := endpoints[0]
+	require.NotNil(t, ep)
+	assert.Equal(t, "/model-provider-types", ep.Path)
+	assert.Equal(t, http.MethodGet, ep.Method)
+	assert.NotNil(t, ep.Handler)
+
+	// Ensure GET handler returns the expected provider types.
+	req := httptest.NewRequest(http.MethodGet, "/model-provider-types", nil)
+	rst := ep.Handler(req)
+	require.NotNil(t, rst)
+	require.NoError(t, rst.OriginErr)
+	types, ok := rst.Data.([]string)
+	require.True(t, ok)
+	assert.Equal(t, []string{"openai", "azure"}, types)
+}

--- a/endpoints/openapi_v1/product/endpoints_test.go
+++ b/endpoints/openapi_v1/product/endpoints_test.go
@@ -1,0 +1,25 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package product
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRouters(t *testing.T) {
+	assert.Empty(t, Routers)
+}

--- a/endpoints/openapi_v1/route/endpoints_test.go
+++ b/endpoints/openapi_v1/route/endpoints_test.go
@@ -1,0 +1,31 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 1)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+}

--- a/endpoints/openapi_v1/route/expression_verify_test.go
+++ b/endpoints/openapi_v1/route/expression_verify_test.go
@@ -1,0 +1,92 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/endpoints/openapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/model/ibasic"
+	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
+	"github.com/yf-networks/ai-gateway-api/model/iroute_conf"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeRouteRuleStorager struct{}
+
+func (f *fakeRouteRuleStorager) UpsertProductRule(ctx context.Context, product *ibasic.Product, rule *iroute_conf.ProductRouteRule) error {
+	return nil
+}
+
+func (f *fakeRouteRuleStorager) FetchProductRule(ctx context.Context, product *ibasic.Product, clusterList []*icluster_conf.Cluster) (*iroute_conf.ProductRouteRule, error) {
+	return nil, nil
+}
+
+func (f *fakeRouteRuleStorager) FetchRoutRules(ctx context.Context, products []*ibasic.Product, clusters []*icluster_conf.Cluster) (map[int64]*iroute_conf.ProductRouteRule, error) {
+	return nil, nil
+}
+
+func setupRouteRuleManager() func() {
+	old := container.RouteRuleManager
+	container.RouteRuleManager = iroute_conf.NewRouteRuleManager(
+		&testutil.FakeTxn{},
+		&fakeRouteRuleStorager{},
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	return func() {
+		container.RouteRuleManager = old
+	}
+}
+
+func TestExpressionVerifyActionProcess_Success(t *testing.T) {
+	defer setupRouteRuleManager()()
+
+	req := httptest.NewRequest(http.MethodPatch, "/expression/verify", strings.NewReader(`{"expression": "default_t()"}`))
+	data, err := ExpressionVerifyAction(req)
+
+	require.NoError(t, err)
+	assert.Nil(t, data)
+}
+
+func TestExpressionVerifyActionProcess_InvalidExpression(t *testing.T) {
+	defer setupRouteRuleManager()()
+
+	req := httptest.NewRequest(http.MethodPatch, "/expression/verify", strings.NewReader(`{"expression": "invalid(@"}`))
+	data, err := ExpressionVerifyAction(req)
+
+	require.Error(t, err)
+	result, ok := data.(*VerifyResult)
+	require.True(t, ok)
+	assert.Equal(t, 500, result.Code)
+	assert.NotEmpty(t, result.Message)
+}
+
+func TestExpressionVerifyAction_InvalidJSON(t *testing.T) {
+	defer setupRouteRuleManager()()
+
+	req := httptest.NewRequest(http.MethodPatch, "/expression/verify", strings.NewReader(`not-json`))
+	_, err := ExpressionVerifyAction(req)
+
+	require.Error(t, err)
+}

--- a/endpoints/openapi_v1/route_tables/endpoints_test.go
+++ b/endpoints/openapi_v1/route_tables/endpoints_test.go
@@ -1,0 +1,99 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route_tables
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yf-networks/ai-gateway-api/endpoints/openapi_v1/internal/testutil"
+	"github.com/yf-networks/ai-gateway-api/model/shared"
+	"github.com/yf-networks/ai-gateway-api/stateful/container"
+)
+
+type fakeRouteRulesStoragerForTables struct {
+	fetchRouteRulesListFn func(ctx context.Context, filter *shared.RouteRulesFilter) ([]*shared.RouteTableParam, int64, error)
+}
+
+func (f *fakeRouteRulesStoragerForTables) CreateRouteRules(ctx context.Context, ruleType string, owner *string, param *shared.RouteRulesParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeRouteRulesStoragerForTables) FetchRouteRules(ctx context.Context, ruleType string, owner *string) (*shared.RouteRulesParam, error) {
+	return nil, nil
+}
+
+func (f *fakeRouteRulesStoragerForTables) FetchRouteRulesList(ctx context.Context, filter *shared.RouteRulesFilter) ([]*shared.RouteTableParam, int64, error) {
+	if f.fetchRouteRulesListFn != nil {
+		return f.fetchRouteRulesListFn(ctx, filter)
+	}
+	return nil, 0, nil
+}
+
+func (f *fakeRouteRulesStoragerForTables) UpdateRouteRules(ctx context.Context, id int64, param *shared.RouteRulesParam) (int64, error) {
+	return 0, nil
+}
+
+func (f *fakeRouteRulesStoragerForTables) DeleteRouteRules(ctx context.Context, id int64) error {
+	return nil
+}
+
+func (f *fakeRouteRulesStoragerForTables) FetchRouteRulesByID(ctx context.Context, id int64) (*shared.RouteRulesParam, error) {
+	return nil, nil
+}
+
+func setupRouteRulesManagerForTables(storager shared.RouteRulesStorager) func() {
+	old := container.RouteRulesManager
+	container.RouteRulesManager = shared.NewRouteRulesManager(&testutil.FakeTxn{}, storager)
+	return func() {
+		container.RouteRulesManager = old
+	}
+}
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 1)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+}
+
+func TestRouteTablesListAction(t *testing.T) {
+	defer setupRouteRulesManagerForTables(&fakeRouteRulesStoragerForTables{
+		fetchRouteRulesListFn: func(ctx context.Context, filter *shared.RouteRulesFilter) ([]*shared.RouteTableParam, int64, error) {
+			assert.NotNil(t, filter.Page)
+			assert.NotNil(t, filter.PageSize)
+			return []*shared.RouteTableParam{
+				{Type: "global", Owner: "global", Enabled: true},
+			}, 1, nil
+		},
+	})()
+
+	req := httptest.NewRequest(http.MethodGet, "/route-tables?page=2&page_size=50", nil)
+	data, err := RouteTablesListAction(req)
+
+	require.NoError(t, err)
+	resp, ok := data.(*RouteTablesListResponse)
+	require.True(t, ok)
+	assert.Len(t, resp.List, 1)
+	assert.Equal(t, int64(1), resp.Pagination.Total)
+	assert.Equal(t, 2, resp.Pagination.Page)
+	assert.Equal(t, 50, resp.Pagination.PageSize)
+}

--- a/endpoints/openapi_v1/tool/endpoints_test.go
+++ b/endpoints/openapi_v1/tool/endpoints_test.go
@@ -1,0 +1,31 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpoints(t *testing.T) {
+	require.Len(t, Endpoints, 1)
+	for _, ep := range Endpoints {
+		require.NotNil(t, ep)
+		assert.NotEmpty(t, ep.Path)
+		assert.NotEmpty(t, ep.Method)
+	}
+}

--- a/endpoints/openapi_v1/tool/parser_test.go
+++ b/endpoints/openapi_v1/tool/parser_test.go
@@ -1,0 +1,142 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseModelsWithConfig(t *testing.T) {
+	config := &ParserConfig{
+		Providers: map[string]FieldMapping{
+			"openai": {
+				ListPath:  "data",
+				IDField:   "id",
+				NameField: "name",
+			},
+		},
+		DefaultParser: FieldMapping{
+			ListPath:  "data",
+			IDField:   "id",
+			NameField: "name",
+		},
+	}
+
+	response := []byte(`{"data":[{"id":"gpt-4","name":"GPT-4"}]}`)
+	models, err := ParseModelsWithConfig(response, "openai", config)
+
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	assert.Equal(t, "gpt-4", models[0]["id"])
+	assert.Equal(t, "GPT-4", models[0]["name"])
+}
+
+func TestParseModelsWithConfig_UnknownProvider(t *testing.T) {
+	config := &ParserConfig{
+		DefaultParser: FieldMapping{
+			ListPath:  "models",
+			IDField:   "id",
+			NameField: "name",
+		},
+	}
+
+	response := []byte(`{"models":[{"id":"model-1","name":"Model 1"}]}`)
+	models, err := ParseModelsWithConfig(response, "unknown", config)
+
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	assert.Equal(t, "model-1", models[0]["id"])
+}
+
+func TestParseModelsWithConfig_InvalidJSON(t *testing.T) {
+	_, err := ParseModelsWithConfig([]byte("not-json"), "openai", &ParserConfig{})
+	require.Error(t, err)
+}
+
+func TestExtractModelList_Wildcard(t *testing.T) {
+	config := FieldMapping{
+		ListPath: "items.*",
+		IDField:  "id",
+	}
+	data := map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{"id": "m1"},
+		},
+	}
+
+	models, err := extractModelList(data, config)
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	assert.Equal(t, "m1", models[0]["id"])
+}
+
+func TestExtractModelList_PathNotFound(t *testing.T) {
+	config := FieldMapping{ListPath: "missing.path"}
+	_, err := extractModelList(map[string]interface{}{}, config)
+	require.Error(t, err)
+}
+
+func TestExtractModelFields_CustomFields(t *testing.T) {
+	config := FieldMapping{
+		IDField:    "id",
+		NameField:  "name",
+		Created:    "created",
+		OwnerField: "owner",
+		Custom: map[string]string{
+			"vendor": "meta.vendor",
+		},
+	}
+	model := map[string]interface{}{
+		"id":      "m1",
+		"name":    "Model 1",
+		"created": "2024-01-01",
+		"owner":   "team-a",
+		"meta": map[string]interface{}{
+			"vendor": "v1",
+		},
+	}
+
+	result := extractModelFields(model, config)
+	require.NotNil(t, result)
+	assert.Equal(t, "m1", result["id"])
+	assert.Equal(t, "Model 1", result["name"])
+	assert.Equal(t, "2024-01-01", result["created"])
+	assert.Equal(t, "team-a", result["owner"])
+	assert.Equal(t, "v1", result["vendor"])
+}
+
+func TestExtractModelFields_NoID(t *testing.T) {
+	config := FieldMapping{IDField: "id"}
+	model := map[string]interface{}{"name": "Model 1"}
+	assert.Nil(t, extractModelFields(model, config))
+}
+
+func TestGetNestedField(t *testing.T) {
+	data := map[string]interface{}{
+		"a": map[string]interface{}{
+			"b": "value",
+		},
+	}
+
+	value, ok := getNestedField(data, "a.b")
+	require.True(t, ok)
+	assert.Equal(t, "value", value)
+
+	_, ok = getNestedField(data, "a.c")
+	assert.False(t, ok)
+}

--- a/endpoints/openapi_v1/traffic/endpoints_test.go
+++ b/endpoints/openapi_v1/traffic/endpoints_test.go
@@ -1,0 +1,25 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package traffic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndpoints(t *testing.T) {
+	assert.Empty(t, Endpoints)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.8
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/DATA-DOG/go-sqlmock v1.4.0
 	github.com/baidu/go-lib v0.0.0-20210316014414-55daa983069e
 	github.com/bfenetworks/bfe v1.8.1-0.20260427052401-8d3a8cd44d98
 	github.com/codegangsta/negroni v1.0.0
@@ -15,6 +16,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.0
 	github.com/go-playground/validator/v10 v10.9.0
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
@@ -34,7 +36,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect

--- a/stateful/config_database_test.go
+++ b/stateful/config_database_test.go
@@ -1,0 +1,84 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stateful
+
+import (
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDbConfig_FormatDSN(t *testing.T) {
+	t.Run("mysql driver", func(t *testing.T) {
+		cfg := &DbConfig{
+			Driver: DriverMySQL,
+			Config: mysql.Config{
+				User:   "user",
+				Passwd: "pass",
+				Net:    "tcp",
+				Addr:   "127.0.0.1:3306",
+				DBName: "bfe",
+			},
+		}
+		dsn, err := cfg.FormatDSN()
+		require.NoError(t, err)
+		assert.Contains(t, dsn, "user:pass@tcp(127.0.0.1:3306)/bfe")
+	})
+
+	t.Run("sqlite driver", func(t *testing.T) {
+		cfg := &DbConfig{
+			Driver: DriverSQLite,
+			Config: mysql.Config{
+				DBName: ":memory:",
+			},
+		}
+		dsn, err := cfg.FormatDSN()
+		require.NoError(t, err)
+		assert.Equal(t, ":memory:", dsn)
+	})
+
+	t.Run("sqlite-strip driver", func(t *testing.T) {
+		cfg := &DbConfig{
+			Driver: "sqlite-strip",
+			Config: mysql.Config{
+				DBName: "/tmp/test.db",
+			},
+		}
+		dsn, err := cfg.FormatDSN()
+		require.NoError(t, err)
+		assert.Equal(t, "/tmp/test.db", dsn)
+	})
+
+	t.Run("sqlite driver without dbname", func(t *testing.T) {
+		cfg := &DbConfig{
+			Driver: DriverSQLite,
+			Config: mysql.Config{
+				DBName: "",
+			},
+		}
+		_, err := cfg.FormatDSN()
+		require.Error(t, err)
+	})
+
+	t.Run("unsupported driver", func(t *testing.T) {
+		cfg := &DbConfig{
+			Driver: "postgres",
+		}
+		_, err := cfg.FormatDSN()
+		require.Error(t, err)
+	})
+}

--- a/stateful/config_depends_test.go
+++ b/stateful/config_depends_test.go
@@ -1,0 +1,110 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stateful
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNavTree_matchRole(t *testing.T) {
+	tests := []struct {
+		name     string
+		tree     *NavTree
+		role     string
+		expected bool
+	}{
+		{
+			name:     "nil allow roles matches all",
+			tree:     &NavTree{ID: "root"},
+			role:     "admin",
+			expected: true,
+		},
+		{
+			name:     "role in allow list",
+			tree:     &NavTree{ID: "root", AllowRoles: []string{"admin", "user"}},
+			role:     "admin",
+			expected: true,
+		},
+		{
+			name:     "role not in allow list",
+			tree:     &NavTree{ID: "root", AllowRoles: []string{"admin"}},
+			role:     "user",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.tree.matchRole(tt.role))
+		})
+	}
+}
+
+func TestNavTree_deriveByRole(t *testing.T) {
+	root := &NavTree{
+		ID:         "root",
+		Text:       "Root",
+		AllowRoles: []string{"admin", "user"},
+		Children: []*NavTree{
+			{
+				ID:         "admin-only",
+				Text:       "Admin Only",
+				AllowRoles: []string{"admin"},
+			},
+			{
+				ID:   "public",
+				Text: "Public",
+				Children: []*NavTree{
+					{
+						ID:         "user-child",
+						Text:       "User Child",
+						AllowRoles: []string{"user"},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("admin role", func(t *testing.T) {
+		derived, err := root.deriveByRole("admin")
+		require.NoError(t, err)
+		require.NotNil(t, derived)
+		assert.Equal(t, "root", derived.ID)
+		// "public" node is pruned because its only child "user-child" is not
+		// visible to the admin role and "public" itself has no role restriction.
+		require.Len(t, derived.Children, 1)
+		assert.Equal(t, "admin-only", derived.Children[0].ID)
+	})
+
+	t.Run("user role", func(t *testing.T) {
+		derived, err := root.deriveByRole("user")
+		require.NoError(t, err)
+		require.NotNil(t, derived)
+		assert.Equal(t, "root", derived.ID)
+		require.Len(t, derived.Children, 1)
+		assert.Equal(t, "public", derived.Children[0].ID)
+		require.Len(t, derived.Children[0].Children, 1)
+		assert.Equal(t, "user-child", derived.Children[0].Children[0].ID)
+	})
+
+	t.Run("unauthorized role", func(t *testing.T) {
+		derived, err := root.deriveByRole("guest")
+		require.NoError(t, err)
+		assert.Nil(t, derived)
+	})
+}

--- a/stateful/config_redis_test.go
+++ b/stateful/config_redis_test.go
@@ -1,0 +1,27 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stateful
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAIUsedQuotaKey(t *testing.T) {
+	assert.Equal(t, "QUOTA_user_123", AIUsedQuotaKey("user_123"))
+	assert.Equal(t, "QUOTA_", AIUsedQuotaKey(""))
+	assert.Equal(t, "QUOTA_deepseek:v1", AIUsedQuotaKey("deepseek:v1"))
+}

--- a/stateful/config_test.go
+++ b/stateful/config_test.go
@@ -1,0 +1,54 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stateful
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Init(t *testing.T) {
+	cfg := &Config{
+		Vars: map[string]string{
+			"conf_dir": "/etc/ai-gateway",
+		},
+		Depends: DependsConfig{
+			NavTreeFile: "${conf_dir}/nav_tree.toml",
+			I18nDir:     "${conf_dir}/i18n",
+		},
+	}
+
+	require.NoError(t, cfg.Init())
+
+	assert.Equal(t, "/etc/ai-gateway/nav_tree.toml", cfg.Depends.NavTreeFile)
+	assert.Equal(t, "/etc/ai-gateway/i18n", cfg.Depends.I18nDir)
+}
+
+func TestConfig_Init_NoVariables(t *testing.T) {
+	cfg := &Config{
+		Vars: map[string]string{},
+		Depends: DependsConfig{
+			NavTreeFile: "/absolute/nav_tree.toml",
+			I18nDir:     "/absolute/i18n",
+		},
+	}
+
+	require.NoError(t, cfg.Init())
+
+	assert.Equal(t, "/absolute/nav_tree.toml", cfg.Depends.NavTreeFile)
+	assert.Equal(t, "/absolute/i18n", cfg.Depends.I18nDir)
+}

--- a/stateful/i18n_test.go
+++ b/stateful/i18n_test.go
@@ -1,0 +1,113 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stateful
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLangMapping(t *testing.T) {
+	t.Run("valid regex without placeholder", func(t *testing.T) {
+		mm, err := NewLangMapping(`^not found$`, "未找到")
+		require.NoError(t, err)
+		assert.NotNil(t, mm.fromRegex)
+		assert.Equal(t, 0, mm.placeholderCount)
+	})
+
+	t.Run("valid regex with placeholder", func(t *testing.T) {
+		mm, err := NewLangMapping(`invalid value: (.*)$`, "无效值: %s")
+		require.NoError(t, err)
+		assert.Equal(t, 1, mm.placeholderCount)
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		mm, err := NewLangMapping(`[`, "x")
+		require.Error(t, err)
+		assert.Nil(t, mm)
+	})
+}
+
+func TestLangMapping_TryTrans(t *testing.T) {
+	t.Run("no regex initialized", func(t *testing.T) {
+		mm := &LangMapping{From: "x", To: "y"}
+		got, ok := mm.TryTrans("x")
+		assert.False(t, ok)
+		assert.Equal(t, "x", got)
+	})
+
+	t.Run("match without placeholder", func(t *testing.T) {
+		mm, err := NewLangMapping(`^not found$`, "未找到")
+		require.NoError(t, err)
+		got, ok := mm.TryTrans("not found")
+		assert.True(t, ok)
+		assert.Equal(t, "未找到", got)
+	})
+
+	t.Run("match with placeholder", func(t *testing.T) {
+		mm, err := NewLangMapping(`invalid value: (.*)$`, "无效值: %s")
+		require.NoError(t, err)
+		got, ok := mm.TryTrans("invalid value: foo")
+		assert.True(t, ok)
+		assert.Equal(t, "无效值: foo", got)
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		mm, err := NewLangMapping(`^not found$`, "未找到")
+		require.NoError(t, err)
+		got, ok := mm.TryTrans("error")
+		assert.False(t, ok)
+		assert.Equal(t, "error", got)
+	})
+}
+
+func TestTryMappingErrMsg(t *testing.T) {
+	// Backup and restore global language packs.
+	oldLangs := langs2languagePacks
+	defer func() { langs2languagePacks = oldLangs }()
+
+	langs2languagePacks = map[string]map[string]*LangMapping{
+		"zh": {
+			"ParamError": {
+				From: "ParamError",
+				To:   "参数错误",
+			},
+			`^value (.*) is invalid$`: func() *LangMapping {
+				mm, _ := NewLangMapping(`^value (.*) is invalid$`, "值 %s 无效")
+				return mm
+			}(),
+		},
+	}
+
+	t.Run("empty message", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
+		assert.Equal(t, "", TryMappingErrMsg(req, ""))
+	})
+
+	t.Run("no matching language pack", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Accept-Language", "fr")
+		assert.Equal(t, "ParamError: value foo is invalid", TryMappingErrMsg(req, "ParamError: value foo is invalid"))
+	})
+
+	t.Run("translate type and message", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/", nil)
+		req.Header.Set("Accept-Language", "zh")
+		assert.Equal(t, "参数错误: 值 foo 无效", TryMappingErrMsg(req, "ParamError: value foo is invalid"))
+	})
+}

--- a/stateful/mock_redis_test.go
+++ b/stateful/mock_redis_test.go
@@ -1,0 +1,104 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stateful
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockRedisClient_IncrAndGet(t *testing.T) {
+	client := NewMockRedisClient()
+
+	val, err := client.Incr("counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+
+	val, err = client.IncrBy("counter", 4)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), val)
+
+	got, err := client.GetInt64("counter")
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), got)
+}
+
+func TestMockRedisClient_Decr(t *testing.T) {
+	client := NewMockRedisClient()
+
+	_, err := client.Incr("balance")
+	require.NoError(t, err)
+
+	val, err := client.Decr("balance")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), val)
+}
+
+func TestMockRedisClient_GetMissingKey(t *testing.T) {
+	client := NewMockRedisClient()
+
+	v, err := client.Get("missing")
+	require.NoError(t, err)
+	assert.Nil(t, v)
+
+	got, err := client.GetInt64("missing")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got)
+}
+
+func TestMockRedisClient_SetexAndExpire(t *testing.T) {
+	client := NewMockRedisClient()
+
+	require.NoError(t, client.Setex("key", []byte("value"), 60))
+	require.NoError(t, client.Expire("key", 120))
+
+	got, err := client.GetInt64("key")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got)
+}
+
+func TestMockRedisClient_PIncr(t *testing.T) {
+	client := NewMockRedisClient()
+
+	results, err := client.PIncr([]string{"a", "b", "a"})
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	assert.Equal(t, int64(1), results[0])
+	assert.Equal(t, int64(1), results[1])
+	assert.Equal(t, int64(2), results[2])
+}
+
+func TestMockRedisClient_IncrAndExpire(t *testing.T) {
+	client := NewMockRedisClient()
+
+	val, err := client.IncrAndExpire("quota", 3600)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), val)
+}
+
+func TestMockRedisClient_Reset(t *testing.T) {
+	client := NewMockRedisClient()
+
+	_, err := client.Incr("x")
+	require.NoError(t, err)
+
+	client.Reset()
+
+	got, err := client.GetInt64("x")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got)
+}

--- a/stateful/sql_record_test.go
+++ b/stateful/sql_record_test.go
@@ -1,0 +1,55 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stateful
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSQLRecord_format(t *testing.T) {
+	t.Run("intercept insert values", func(t *testing.T) {
+		sr := &SQLRecord{
+			SQL: "INSERT INTO mod_header_rules (actions,cond) VALUES ('[{}]','cond')",
+		}
+		sr.format()
+		assert.Equal(t, "INSERT INTO mod_header_rules (actions,cond)intercept", sr.SQL)
+	})
+
+	t.Run("replace in clause", func(t *testing.T) {
+		sr := &SQLRecord{
+			SQL: "SELECT * FROM users WHERE id IN (?, ?, ?)",
+		}
+		sr.format()
+		assert.Equal(t, "SELECT * FROM users WHERE id IN(intercept)", sr.SQL)
+	})
+
+	t.Run("replace lowercase in clause", func(t *testing.T) {
+		sr := &SQLRecord{
+			SQL: "select * from users where id in (?, ?)",
+		}
+		sr.format()
+		assert.Equal(t, "select * from users where id IN(intercept)", sr.SQL)
+	})
+
+	t.Run("no change for simple select", func(t *testing.T) {
+		sr := &SQLRecord{
+			SQL: "SELECT * FROM users WHERE id = ?",
+		}
+		sr.format()
+		assert.Equal(t, "SELECT * FROM users WHERE id = ?", sr.SQL)
+	})
+}

--- a/stateful/sqlite_strip_test.go
+++ b/stateful/sqlite_strip_test.go
@@ -1,0 +1,56 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stateful
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripForUpdate(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{
+			name:  "with for update",
+			query: "SELECT * FROM users WHERE id = ? FOR UPDATE",
+			want:  "SELECT * FROM users WHERE id = ?",
+		},
+		{
+			name:  "with lowercase for update",
+			query: "select * from users for update",
+			want:  "select * from users",
+		},
+		{
+			name:  "without for update",
+			query: "SELECT * FROM users WHERE id = ?",
+			want:  "SELECT * FROM users WHERE id = ?",
+		},
+		{
+			name:  "for update in the middle",
+			query: "SELECT * FOR UPDATE FROM users",
+			want:  "SELECT *",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripForUpdate(tt.query))
+		})
+	}
+}

--- a/storage/rdb/internal/dao/internal/builder_test.go
+++ b/storage/rdb/internal/dao/internal/builder_test.go
@@ -1,0 +1,154 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testRecord struct {
+	ID     int64   `db:"id"`
+	Name   string  `db:"name"`
+	Status *int    `db:"status"`
+	Ignore string  `db:"-"`
+	Age    int     `db:"age,>"`
+	Tags   []string `db:"tags"`
+}
+
+func TestStruct2Where(t *testing.T) {
+	status := 1
+	r := &testRecord{
+		ID:     10,
+		Name:   "foo",
+		Status: &status,
+		Ignore: "ignored",
+		Age:    18,
+		Tags:   []string{"a", "b"},
+	}
+
+	m := Struct2Where(r)
+	assert.Equal(t, int64(10), m["id"])
+	assert.Equal(t, "foo", m["name"])
+	assert.Equal(t, 1, m["status"])
+	assert.Equal(t, 18, m["age >"])
+	assert.Equal(t, []string{"a", "b"}, m["tags"])
+	assert.NotContains(t, m, "ignore")
+	assert.NotContains(t, m, "-")
+}
+
+func TestStruct2Where_ZeroValue(t *testing.T) {
+	r := &testRecord{}
+	m := Struct2Where(r)
+	// Zero-value primitive fields are still included unless they are pointers.
+	assert.Equal(t, int64(0), m["id"])
+	assert.Equal(t, "", m["name"])
+	assert.Equal(t, 0, m["age >"])
+	// Nil pointer and empty slice are omitted.
+	assert.NotContains(t, m, "status")
+	assert.NotContains(t, m, "tags")
+}
+
+func TestStruct2Assign(t *testing.T) {
+	status := 2
+	r := &testRecord{
+		ID:     20,
+		Name:   "bar",
+		Status: &status,
+		Age:    21,
+	}
+
+	m := Struct2Assign(r)
+	assert.Equal(t, int64(20), m["id"])
+	assert.Equal(t, "bar", m["name"])
+	assert.Equal(t, 2, m["status"])
+	// Options are ignored for assignments.
+	assert.Equal(t, 21, m["age"])
+}
+
+func TestStruct2AssignList(t *testing.T) {
+	rs := []testRecord{
+		{ID: 1, Name: "a"},
+		{ID: 2, Name: "b"},
+	}
+	ms := Struct2AssignList(rs[0], rs[1])
+	require.Len(t, ms, 2)
+	assert.Equal(t, int64(1), ms[0]["id"])
+	assert.Equal(t, "a", ms[0]["name"])
+	assert.Equal(t, int64(2), ms[1]["id"])
+	assert.Equal(t, "b", ms[1]["name"])
+}
+
+func TestTagSplitter(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantKey string
+		wantOpt string
+	}{
+		{"id", "id", ""},
+		{"age,>", "age", ">"},
+		{"  name  ,  like  ", "name", "like"},
+		{"", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			key, opt := tagSplitter(tt.input)
+			assert.Equal(t, tt.wantKey, key)
+			assert.Equal(t, tt.wantOpt, opt)
+		})
+	}
+}
+
+func TestSelectBuilder_Compile(t *testing.T) {
+	b := NewSelectBuilder("users", map[string]interface{}{"id": 1}, []string{"id", "name"})
+	sql, args, err := b.Compile()
+	require.NoError(t, err)
+	assert.Contains(t, sql, "SELECT")
+	assert.Contains(t, sql, "FROM users")
+	assert.Contains(t, sql, "WHERE")
+	assert.Len(t, args, 1)
+}
+
+func TestInsertBuilder_Compile(t *testing.T) {
+	b := NewInsertBuilder("users", []map[string]interface{}{
+		{"id": 1, "name": "foo"},
+	})
+	sql, args, err := b.Compile()
+	require.NoError(t, err)
+	assert.Contains(t, sql, "INSERT INTO users")
+	assert.Len(t, args, 2)
+}
+
+func TestUpdateBuilder_Compile(t *testing.T) {
+	b := NewUpdateBuilder("users", map[string]interface{}{"id": 1}, map[string]interface{}{"name": "foo"})
+	sql, args, err := b.Compile()
+	require.NoError(t, err)
+	assert.Contains(t, sql, "UPDATE users")
+	assert.Contains(t, sql, "SET")
+	assert.Contains(t, sql, "WHERE")
+	assert.Len(t, args, 2)
+}
+
+func TestDeleteBuilder_Compile(t *testing.T) {
+	b := NewDeleteBuilder("users", map[string]interface{}{"id": 1})
+	sql, args, err := b.Compile()
+	require.NoError(t, err)
+	assert.Contains(t, sql, "DELETE FROM users")
+	assert.Contains(t, sql, "WHERE")
+	assert.Len(t, args, 1)
+}

--- a/storage/rdb/internal/dao/internal/curd_test.go
+++ b/storage/rdb/internal/dao/internal/curd_test.go
@@ -1,0 +1,142 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yf-networks/ai-gateway-api/lib"
+	"github.com/yf-networks/ai-gateway-api/stateful"
+)
+
+type curdTestRecord struct {
+	ID   int64  `db:"id"`
+	Name string `db:"name"`
+}
+
+type curdTestWhere struct {
+	ID int64 `db:"id"`
+}
+
+type curdTestAssign struct {
+	Name string `db:"name"`
+}
+
+func setupCurdTest(t *testing.T) (lib.DBContexter, sqlmock.Sqlmock, func()) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	oldConfig := stateful.DefaultConfig
+	stateful.DefaultConfig = &stateful.Config{
+		RunTime: stateful.RunTimeConfig{
+			RecordSQL: false,
+		},
+	}
+
+	dbCtx := lib.NewDBContext(context.Background(), db)
+	return dbCtx, mock, func() {
+		db.Close()
+		stateful.DefaultConfig = oldConfig
+	}
+}
+
+func TestQueryOne(t *testing.T) {
+	dbCtx, mock, cleanup := setupCurdTest(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "foo")
+	mock.ExpectQuery("SELECT \\* FROM users WHERE \\(id=\\?\\) LIMIT \\?,\\?").WithArgs(1, 0, 1).WillReturnRows(rows)
+
+	var rst curdTestRecord
+	err := QueryOne(dbCtx, "users", &curdTestWhere{ID: 1}, &rst)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rst.ID)
+	assert.Equal(t, "foo", rst.Name)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestQueryOne_NotFound(t *testing.T) {
+	dbCtx, mock, cleanup := setupCurdTest(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"id", "name"})
+	mock.ExpectQuery("SELECT \\* FROM users WHERE \\(id=\\?\\) LIMIT \\?,\\?").WithArgs(99, 0, 1).WillReturnRows(rows)
+
+	var rst curdTestRecord
+	err := QueryOne(dbCtx, "users", &curdTestWhere{ID: 99}, &rst)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sql.ErrNoRows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestQueryList(t *testing.T) {
+	dbCtx, mock, cleanup := setupCurdTest(t)
+	defer cleanup()
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(1, "foo").
+		AddRow(2, "bar")
+	mock.ExpectQuery("SELECT \\* FROM users").WillReturnRows(rows)
+
+	var rst []*curdTestRecord
+	err := QueryList(dbCtx, "users", &curdTestWhere{}, &rst)
+	require.NoError(t, err)
+	require.Len(t, rst, 2)
+	assert.Equal(t, "foo", rst[0].Name)
+	assert.Equal(t, "bar", rst[1].Name)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestCreate(t *testing.T) {
+	dbCtx, mock, cleanup := setupCurdTest(t)
+	defer cleanup()
+
+	mock.ExpectExec("INSERT INTO users").WithArgs(int64(1), "foo").WillReturnResult(sqlmock.NewResult(1, 1))
+
+	id, err := Create(dbCtx, "users", &curdTestRecord{ID: 1, Name: "foo"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), id)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUpdate(t *testing.T) {
+	dbCtx, mock, cleanup := setupCurdTest(t)
+	defer cleanup()
+
+	mock.ExpectExec("UPDATE users").WithArgs("foo", 1).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rows, err := Update(dbCtx, "users", &curdTestWhere{ID: 1}, &curdTestAssign{Name: "foo"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestDelete(t *testing.T) {
+	dbCtx, mock, cleanup := setupCurdTest(t)
+	defer cleanup()
+
+	mock.ExpectExec("DELETE FROM users").WithArgs(1).WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rows, err := Delete(dbCtx, "users", &curdTestWhere{ID: 1})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), rows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/storage/rdb/quota/quota_balance_test.go
+++ b/storage/rdb/quota/quota_balance_test.go
@@ -1,0 +1,78 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package quota
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yf-networks/ai-gateway-api/model/quota"
+	"github.com/yf-networks/ai-gateway-api/storage/rdb/internal/dao"
+)
+
+func TestQuotaBalanceFilterToParam(t *testing.T) {
+	id := int64(1)
+	planID := int64(2)
+
+	param := quotaBalanceFilterToParam(&quota.QuotaBalanceFilter{
+		ID:          &id,
+		QuotaPlanID: &planID,
+	})
+
+	assert.Equal(t, &id, param.ID)
+	assert.Equal(t, &planID, param.QuotaPlanID)
+
+	assert.Nil(t, quotaBalanceFilterToParam(nil))
+}
+
+func TestQuotaBalanceDataToParam(t *testing.T) {
+	planID := int64(10)
+	used := int64(5)
+	remaining := int64(95)
+	lastReset := time.Now()
+
+	param := quotaBalanceDataToParam(&quota.QuotaBalanceParam{
+		QuotaPlanID: &planID,
+		Used:        &used,
+		Remaining:   &remaining,
+		LastResetAt: &lastReset,
+	})
+
+	assert.Equal(t, &planID, param.QuotaPlanID)
+	assert.Equal(t, &used, param.Used)
+	assert.Equal(t, &remaining, param.Remaining)
+	assert.Equal(t, &lastReset, param.LastResetAt)
+}
+
+func TestQuotaBalanceParamToData(t *testing.T) {
+	now := time.Now()
+	data := &dao.TQuotaBalance{
+		ID:          1,
+		QuotaPlanID: 2,
+		Used:        3,
+		Remaining:   4,
+		LastResetAt: &now,
+	}
+
+	param := quotaBalanceParamToData(data)
+
+	assert.Equal(t, int64(1), *param.ID)
+	assert.Equal(t, int64(2), *param.QuotaPlanID)
+	assert.Equal(t, int64(3), *param.Used)
+	assert.Equal(t, int64(4), *param.Remaining)
+	assert.Equal(t, &now, param.LastResetAt)
+}

--- a/storage/rdb/txn/txn_test.go
+++ b/storage/rdb/txn/txn_test.go
@@ -1,0 +1,90 @@
+// Copyright(c) 2026 Beijing Yingfei Networks Technology Co.Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txn
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yf-networks/ai-gateway-api/lib"
+)
+
+func setupTxnTest(t *testing.T) (*RDBTxnStorager, sqlmock.Sqlmock, func()) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+
+	factory := func(ctx context.Context, ops ...*lib.Op) (*lib.DBContext, error) {
+		return lib.NewDBContext(ctx, db), nil
+	}
+
+	return NewRDBTxnStorager(factory), mock, func() {
+		db.Close()
+	}
+}
+
+func TestRDBTxnStorager_AtomExecute_Commit(t *testing.T) {
+	storager, mock, cleanup := setupTxnTest(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	executed := false
+	err := storager.AtomExecute(context.Background(), func(ctx context.Context) error {
+		executed = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.True(t, executed)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRDBTxnStorager_AtomExecute_Rollback(t *testing.T) {
+	storager, mock, cleanup := setupTxnTest(t)
+	defer cleanup()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	expectedErr := errors.New("business error")
+	err := storager.AtomExecute(context.Background(), func(ctx context.Context) error {
+		return expectedErr
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestRDBTxnStorager_AtomExecute_FactoryError(t *testing.T) {
+	expectedErr := errors.New("factory error")
+	factory := func(ctx context.Context, ops ...*lib.Op) (*lib.DBContext, error) {
+		return nil, expectedErr
+	}
+
+	storager := NewRDBTxnStorager(factory)
+	err := storager.AtomExecute(context.Background(), func(ctx context.Context) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+}


### PR DESCRIPTION
- Refactor model_provider_type endpoints to use NewEndpoints with injectable config reader
- Add unit tests for stateful package (config, i18n, mock redis, sqlite strip, sql record)
- Add unit tests for storage package (dao builder, curd, txn, quota balance)
- Add go-sqlmock dependency for database mocking