### PR TITLE
fix(cluster): sticky_sessions 默认值改为 CLIENT_IP_ONLY 并校验 enabled=true 时…

### DIFF
--- a/design-docs/api-define/OpenAPI接口定义/clusters.md
+++ b/design-docs/api-define/OpenAPI接口定义/clusters.md
@@ -36,8 +36,8 @@
     },
     "sticky_sessions": {
         "enabled": false,
-        "hash_strategy": "CLIENT_ID_ONLY",
-        "hash_header": "Cookie:USERID"
+        "hash_strategy": "CLIENT_IP_ONLY",
+        "hash_header": ""
     },
     "passive_health_check": {
         "interval": 1000,
@@ -103,8 +103,8 @@
 | 参数名 | 类型 |参数含义 | 必填 | 补充描述 | 合法性条件 |
 | - | -  | - | - | - | - |
 | enabled| bool |  是否开启会话保持 | N | **默认false**。为true时开启会话保持；为false时关闭 | 非必填；默认值为 `false` |
-| hash_strategy| string |  会话保持策略  | N | CLIENT_IP_ONLY，根据client ip做会话保持 <br/>	CLIENT_ID_ONLY，根据请求中header做会话保持(默认值) <br>	CLIENT_ID_PERFERED，优先基于特定header，如果请求中没有对应header，则使用client ip| 非必填；默认值为 `CLIENT_ID_ONLY`；有效枚举：`CLIENT_IP_ONLY`、`CLIENT_ID_ONLY`、`CLIENT_ID_PREFERED` |
-| hash_header| string |  指定CLIENT_ID使用的header | N | 当使用cookie作为会话保持的哈希key时，数据格式为Cookie:${key} | 非必填；默认值为空字符串；`hash_strategy` 为 `CLIENT_ID_ONLY` 或 `CLIENT_ID_PREFERED` 时建议非空 |
+| hash_strategy| string |  会话保持策略  | N | CLIENT_IP_ONLY，根据client ip做会话保持(默认值) <br/>	CLIENT_ID_ONLY，根据请求中header做会话保持 <br>	CLIENT_ID_PERFERED，优先基于特定header，如果请求中没有对应header，则使用client ip| 非必填；默认值为 `CLIENT_IP_ONLY`；有效枚举：`CLIENT_IP_ONLY`、`CLIENT_ID_ONLY`、`CLIENT_ID_PREFERED` |
+| hash_header| string |  指定CLIENT_ID使用的header | N | 当使用cookie作为会话保持的哈希key时，数据格式为Cookie:${key} | 非必填；默认值为空字符串；`enabled=true` 且 `hash_strategy` 为 `CLIENT_ID_ONLY` 或 `CLIENT_ID_PREFERED` 时必须非空 |
 
 **表：超时设置**
 
@@ -245,8 +245,8 @@
     },
     "sticky_sessions": {
         "enabled": false,
-        "hash_strategy": "CLIENT_ID_ONLY",
-        "hash_header": "Cookie:USERID"
+        "hash_strategy": "CLIENT_IP_ONLY",
+        "hash_header": ""
     },
     "passive_health_check": {
         "interval": 1000,
@@ -424,8 +424,8 @@
     },
     "sticky_sessions": {
         "enabled": false,
-        "hash_strategy": "CLIENT_ID_ONLY",
-        "hash_header": "Cookie:USERID"
+        "hash_strategy": "CLIENT_IP_ONLY",
+        "hash_header": ""
     },
     "passive_health_check": {
         "interval": 1000,

--- a/design-docs/sys-design/模型层设计文档.md
+++ b/design-docs/sys-design/模型层设计文档.md
@@ -496,8 +496,8 @@ Cluster 对外模型与存储模型解耦，不再暴露 `ready`、`sub_clusters
     },
     "sticky_sessions": {
         "enabled": false,
-        "hash_strategy": "CLIENT_ID_ONLY",
-        "hash_header": "Cookie:USERID"
+        "hash_strategy": "CLIENT_IP_ONLY",
+        "hash_header": ""
     },
     "passive_health_check": {
         "interval": 1000,

--- a/endpoints/openapi_v1/product_cluster/create.go
+++ b/endpoints/openapi_v1/product_cluster/create.go
@@ -128,6 +128,9 @@ func (p *UpsertParam) Validate() error {
 			return err
 		}
 	}
+	if err := validateStickySessions(p.StickySessions); err != nil {
+		return err
+	}
 	if p.LLMConfig != nil {
 		return validate.LLMConfig(p.LLMConfig)
 	}
@@ -147,6 +150,30 @@ var (
 	clusterHashStrategyClientIPOnly     = "CLIENT_IP_ONLY"
 	clusterHashStrategyClientIDPrefered = "CLIENT_ID_PREFERED"
 )
+
+func validateStickySessions(ss *StickySessionsParam) error {
+	if ss == nil || ss.Enabled == nil || !*ss.Enabled {
+		return nil
+	}
+
+	hashStrategy := clusterHashStrategyClientIDOnly
+	if ss.HashStrategy != nil && *ss.HashStrategy != "" {
+		hashStrategy = *ss.HashStrategy
+	}
+
+	switch hashStrategy {
+	case clusterHashStrategyClientIDOnly, clusterHashStrategyClientIDPrefered:
+		if ss.HashHeader == nil || *ss.HashHeader == "" {
+			return xerror.WrapParamErrorWithMsg("sticky_sessions.hash_header is required when enabled and hash_strategy is %s", hashStrategy)
+		}
+	case clusterHashStrategyClientIPOnly:
+	default:
+		return xerror.WrapParamErrorWithMsg("sticky_sessions.hash_strategy must be one of %s, %s, %s",
+			clusterHashStrategyClientIPOnly, clusterHashStrategyClientIDOnly, clusterHashStrategyClientIDPrefered)
+	}
+
+	return nil
+}
 
 func newCreateParam4Create(req *http.Request) (*UpsertParam, error) {
 	param := &UpsertParam{}
@@ -308,7 +335,8 @@ func normalizeStickySessions(ss *StickySessionsParam) *StickySessionsParam {
 		ss.Enabled = lib.PBool(false)
 	}
 	if ss.HashStrategy == nil {
-		ss.HashStrategy = lib.PString(clusterHashStrategyClientIDOnly)
+		// CLIENT_IP_ONLY does not require hash_header, so it is safe as the default.
+		ss.HashStrategy = lib.PString(clusterHashStrategyClientIPOnly)
 	}
 	if ss.HashHeader == nil {
 		ss.HashHeader = lib.PString("")

--- a/endpoints/openapi_v1/product_cluster/create_test.go
+++ b/endpoints/openapi_v1/product_cluster/create_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,87 +18,155 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/yf-networks/ai-gateway-api/lib"
 	"github.com/yf-networks/ai-gateway-api/model/icluster_conf"
 )
 
-func TestUpsertParamValidate(t *testing.T) {
-	cases := []struct {
-		name    string
-		param   *UpsertParam
-		wantErr bool
-	}{
-		{
-			name:    "valid minimal",
-			param:   &UpsertParam{Name: lib.PString("cluster_1")},
-			wantErr: false,
-		},
-		{
-			name:    "missing name",
-			param:   &UpsertParam{},
-			wantErr: true,
-		},
-		{
-			name:    "invalid name",
-			param:   &UpsertParam{Name: lib.PString("-cluster")},
-			wantErr: true,
-		},
-		{
-			name: "valid with instance pool",
-			param: &UpsertParam{
-				Name: lib.PString("cluster_1"),
-				InstancePool: []*Instance{
-					{Name: "host1", Addr: "192.0.2.1", Port: 8080, Weight: 100},
-				},
+func TestNormalizeStickySessions(t *testing.T) {
+	t.Run("nil defaults to disabled CLIENT_IP_ONLY", func(t *testing.T) {
+		got := normalizeStickySessions(nil)
+		require.NotNil(t, got)
+		assert.Equal(t, false, *got.Enabled)
+		assert.Equal(t, clusterHashStrategyClientIPOnly, *got.HashStrategy)
+		assert.Equal(t, "", *got.HashHeader)
+	})
+
+	t.Run("partial values keep provided ones", func(t *testing.T) {
+		got := normalizeStickySessions(&StickySessionsParam{
+			Enabled: lib.PBool(true),
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, true, *got.Enabled)
+		assert.Equal(t, clusterHashStrategyClientIPOnly, *got.HashStrategy)
+		assert.Equal(t, "", *got.HashHeader)
+	})
+}
+
+func TestValidateStickySessions(t *testing.T) {
+	t.Run("nil sticky sessions", func(t *testing.T) {
+		assert.NoError(t, validateStickySessions(nil))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		assert.NoError(t, validateStickySessions(&StickySessionsParam{
+			Enabled:      lib.PBool(false),
+			HashStrategy: lib.PString(clusterHashStrategyClientIDOnly),
+			HashHeader:   lib.PString(""),
+		}))
+	})
+
+	t.Run("enabled with CLIENT_ID_ONLY and hash_header", func(t *testing.T) {
+		assert.NoError(t, validateStickySessions(&StickySessionsParam{
+			Enabled:      lib.PBool(true),
+			HashStrategy: lib.PString(clusterHashStrategyClientIDOnly),
+			HashHeader:   lib.PString("Cookie:USERID"),
+		}))
+	})
+
+	t.Run("enabled with CLIENT_ID_PREFERED and hash_header", func(t *testing.T) {
+		assert.NoError(t, validateStickySessions(&StickySessionsParam{
+			Enabled:      lib.PBool(true),
+			HashStrategy: lib.PString(clusterHashStrategyClientIDPrefered),
+			HashHeader:   lib.PString("Cookie:USERID"),
+		}))
+	})
+
+	t.Run("enabled with CLIENT_IP_ONLY and empty hash_header", func(t *testing.T) {
+		assert.NoError(t, validateStickySessions(&StickySessionsParam{
+			Enabled:      lib.PBool(true),
+			HashStrategy: lib.PString(clusterHashStrategyClientIPOnly),
+			HashHeader:   lib.PString(""),
+		}))
+	})
+
+	t.Run("enabled with default hash_strategy and empty hash_header fails", func(t *testing.T) {
+		err := validateStickySessions(&StickySessionsParam{
+			Enabled:    lib.PBool(true),
+			HashHeader: lib.PString(""),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hash_header is required")
+	})
+
+	t.Run("enabled with CLIENT_ID_ONLY and empty hash_header fails", func(t *testing.T) {
+		err := validateStickySessions(&StickySessionsParam{
+			Enabled:      lib.PBool(true),
+			HashStrategy: lib.PString(clusterHashStrategyClientIDOnly),
+			HashHeader:   lib.PString(""),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hash_header is required")
+	})
+
+	t.Run("enabled with CLIENT_ID_PREFERED and empty hash_header fails", func(t *testing.T) {
+		err := validateStickySessions(&StickySessionsParam{
+			Enabled:      lib.PBool(true),
+			HashStrategy: lib.PString(clusterHashStrategyClientIDPrefered),
+			HashHeader:   lib.PString(""),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hash_header is required")
+	})
+
+	t.Run("invalid hash_strategy", func(t *testing.T) {
+		err := validateStickySessions(&StickySessionsParam{
+			Enabled:      lib.PBool(true),
+			HashStrategy: lib.PString("INVALID"),
+			HashHeader:   lib.PString("Cookie:USERID"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hash_strategy must be one of")
+	})
+}
+
+func TestUpsertParamValidate_StickySessions(t *testing.T) {
+	base := func() *UpsertParam {
+		return &UpsertParam{
+			Name:        lib.PString("test-cluster"),
+			InstancePool: []*Instance{
+				{Name: "rs1", Addr: "127.0.0.1", Port: 80, Weight: 10},
 			},
-			wantErr: false,
-		},
-		{
-			name: "invalid instance pool addr",
-			param: &UpsertParam{
-				Name: lib.PString("cluster_1"),
-				InstancePool: []*Instance{
-					{Name: "host1", Addr: "-invalid", Port: 8080, Weight: 100},
-				},
+			LLMConfig: &icluster_conf.LLMConfig{
+				Models: []string{"gpt-4"},
 			},
-			wantErr: true,
-		},
-		{
-			name: "default name from addr",
-			param: &UpsertParam{
-				Name: lib.PString("cluster_1"),
-				InstancePool: []*Instance{
-					{Addr: "192.0.2.1", Port: 8080, Weight: 100},
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "valid with llm config",
-			param: &UpsertParam{
-				Name:      lib.PString("cluster_1"),
-				LLMConfig: &icluster_conf.LLMConfig{Models: []string{"gpt-4"}},
-			},
-			wantErr: false,
-		},
-		{
-			name: "invalid llm config",
-			param: &UpsertParam{
-				Name:      lib.PString("cluster_1"),
-				LLMConfig: &icluster_conf.LLMConfig{},
-			},
-			wantErr: true,
-		},
+		}
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.param.Validate()
-			if tc.wantErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
+	t.Run("disabled sticky sessions with CLIENT_ID_ONLY and empty hash_header is allowed", func(t *testing.T) {
+		p := base()
+		p.StickySessions = &StickySessionsParam{
+			Enabled:      lib.PBool(false),
+			HashStrategy: lib.PString(clusterHashStrategyClientIDOnly),
+			HashHeader:   lib.PString(""),
+		}
+		assert.NoError(t, p.Validate())
+	})
+
+	t.Run("nil sticky sessions is allowed", func(t *testing.T) {
+		p := base()
+		assert.NoError(t, p.Validate())
+	})
+
+	t.Run("enabled sticky sessions with CLIENT_ID_ONLY and empty hash_header fails", func(t *testing.T) {
+		p := base()
+		p.StickySessions = &StickySessionsParam{
+			Enabled:      lib.PBool(true),
+			HashStrategy: lib.PString(clusterHashStrategyClientIDOnly),
+			HashHeader:   lib.PString(""),
+		}
+		err := p.Validate()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "hash_header is required")
+	})
+
+	t.Run("enabled sticky sessions with CLIENT_ID_ONLY and hash_header passes", func(t *testing.T) {
+		p := base()
+		p.StickySessions = &StickySessionsParam{
+			Enabled:      lib.PBool(true),
+			HashStrategy: lib.PString(clusterHashStrategyClientIDOnly),
+			HashHeader:   lib.PString("Cookie:USERID"),
+		}
+		assert.NoError(t, p.Validate())
+	})
 }

--- a/endpoints/openapi_v1/product_cluster/one_test.go
+++ b/endpoints/openapi_v1/product_cluster/one_test.go
@@ -52,7 +52,7 @@ func TestClusterModel2ControlInstancePoolFields(t *testing.T) {
 		},
 		StickySessions: &icluster_conf.ClusterStickySessions{
 			SessionSticky: false,
-			HashStrategy:  icluster_conf.ClusterHashStrategyClientIDOnlyI,
+			HashStrategy:  icluster_conf.ClusterHashStrategyClientIPOnlyI,
 			HashHeader:    "",
 		},
 		PassiveHealthCheck: &icluster_conf.ClusterPassiveHealthCheck{

--- a/model/icluster_conf/cluster.go
+++ b/model/icluster_conf/cluster.go
@@ -767,6 +767,23 @@ func AppendAdvancedRuleCluster(list []*Cluster) []*Cluster {
 	})
 }
 
+func normalizeBFEHashStrategy(sticky *ClusterStickySessions) int32 {
+	if sticky == nil {
+		return ClusterHashStrategyClientIPOnlyI
+	}
+
+	// BFE requires HashHeader to be non-empty when HashStrategy is CLIENT_ID_ONLY
+	// or CLIENT_ID_PREFERRED. If session sticky is disabled and no HashHeader is
+	// provided, fall back to CLIENT_IP_ONLY to keep the generated config valid.
+	if !sticky.SessionSticky && sticky.HashHeader == "" &&
+		(sticky.HashStrategy == ClusterHashStrategyClientIDOnlyI ||
+			sticky.HashStrategy == ClusterHashStrategyClientIDPreferedI) {
+		return ClusterHashStrategyClientIPOnlyI
+	}
+
+	return sticky.HashStrategy
+}
+
 func NewBfeClusterConf(version string, clusters []*Cluster) *cluster_conf.BfeClusterConf {
 	clusterConfMap := cluster_conf.ClusterToConf{}
 
@@ -800,7 +817,7 @@ func NewBfeClusterConf(version string, clusters []*Cluster) *cluster_conf.BfeClu
 				CrossRetry: int82intp(cluster.Basic.Retries.MaxRetryCrossSubcluster),
 				RetryMax:   int82intp(cluster.Basic.Retries.MaxRetryInSubcluster),
 				HashConf: &cluster_conf.HashConf{
-					HashStrategy:  int322intp(cluster.StickySessions.HashStrategy),
+					HashStrategy:  int322intp(normalizeBFEHashStrategy(cluster.StickySessions)),
 					HashHeader:    &cluster.StickySessions.HashHeader,
 					SessionSticky: &cluster.StickySessions.SessionSticky,
 				},

--- a/model/icluster_conf/cluster_test.go
+++ b/model/icluster_conf/cluster_test.go
@@ -794,6 +794,67 @@ func TestNewBfeClusterConf(t *testing.T) {
 		require.NotNil(t, cConf.AIConf.ModelMapping)
 		assert.Equal(t, "new", (*cConf.AIConf.ModelMapping)["old"])
 	})
+
+	t.Run("disabled sticky sessions with empty hash_header falls back to CLIENT_IP_ONLY", func(t *testing.T) {
+		c := newTestClusterBase()
+		c.StickySessions = &ClusterStickySessions{
+			SessionSticky: false,
+			HashStrategy:  ClusterHashStrategyClientIDOnlyI,
+			HashHeader:    "",
+		}
+		conf := NewBfeClusterConf("v1", []*Cluster{c})
+		cConf := (*conf.Config)["c1"]
+		require.NotNil(t, cConf.GslbBasic)
+		require.NotNil(t, cConf.GslbBasic.HashConf)
+		require.NotNil(t, cConf.GslbBasic.HashConf.HashStrategy)
+		assert.Equal(t, ClusterHashStrategyClientIPOnlyI, int32(*cConf.GslbBasic.HashConf.HashStrategy))
+	})
+}
+
+func TestNormalizeBFEHashStrategy(t *testing.T) {
+	t.Run("nil sticky sessions", func(t *testing.T) {
+		assert.Equal(t, ClusterHashStrategyClientIPOnlyI, normalizeBFEHashStrategy(nil))
+	})
+
+	t.Run("disabled CLIENT_ID_ONLY with empty header", func(t *testing.T) {
+		assert.Equal(t, ClusterHashStrategyClientIPOnlyI, normalizeBFEHashStrategy(&ClusterStickySessions{
+			SessionSticky: false,
+			HashStrategy:  ClusterHashStrategyClientIDOnlyI,
+			HashHeader:    "",
+		}))
+	})
+
+	t.Run("disabled CLIENT_ID_PREFERRED with empty header", func(t *testing.T) {
+		assert.Equal(t, ClusterHashStrategyClientIPOnlyI, normalizeBFEHashStrategy(&ClusterStickySessions{
+			SessionSticky: false,
+			HashStrategy:  ClusterHashStrategyClientIDPreferedI,
+			HashHeader:    "",
+		}))
+	})
+
+	t.Run("disabled CLIENT_ID_ONLY with non-empty header stays", func(t *testing.T) {
+		assert.Equal(t, ClusterHashStrategyClientIDOnlyI, normalizeBFEHashStrategy(&ClusterStickySessions{
+			SessionSticky: false,
+			HashStrategy:  ClusterHashStrategyClientIDOnlyI,
+			HashHeader:    "Cookie:USERID",
+		}))
+	})
+
+	t.Run("enabled CLIENT_ID_ONLY stays", func(t *testing.T) {
+		assert.Equal(t, ClusterHashStrategyClientIDOnlyI, normalizeBFEHashStrategy(&ClusterStickySessions{
+			SessionSticky: true,
+			HashStrategy:  ClusterHashStrategyClientIDOnlyI,
+			HashHeader:    "Cookie:USERID",
+		}))
+	})
+
+	t.Run("disabled CLIENT_IP_ONLY stays", func(t *testing.T) {
+		assert.Equal(t, ClusterHashStrategyClientIPOnlyI, normalizeBFEHashStrategy(&ClusterStickySessions{
+			SessionSticky: false,
+			HashStrategy:  ClusterHashStrategyClientIPOnlyI,
+			HashHeader:    "",
+		}))
+	})
 }
 
 func TestConvertToBFEModelMapping(t *testing.T) {

--- a/test/integration/tests/clusters/create/create_test.go
+++ b/test/integration/tests/clusters/create/create_test.go
@@ -69,6 +69,13 @@ func TestClusters_Create(t *testing.T) {
 				json.Unmarshal(resp.Data, &data)
 				assertNoInternalFields(t, data)
 				testutil.AssertDataFieldEquals(t, resp, "name", clusterMin)
+
+				sticky, ok := data["sticky_sessions"].(map[string]interface{})
+				if assert.True(t, ok, "sticky_sessions should be an object") {
+					assert.Equal(t, false, sticky["enabled"])
+					assert.Equal(t, "CLIENT_IP_ONLY", sticky["hash_strategy"])
+					assert.Equal(t, "", sticky["hash_header"])
+				}
 			},
 		},
 		{

--- a/test/integration/tests/clusters/design.md
+++ b/test/integration/tests/clusters/design.md
@@ -240,8 +240,8 @@ clusters/
     },
     "sticky_sessions": {
         "enabled": false,
-        "hash_strategy": "CLIENT_ID_ONLY",
-        "hash_header": "Cookie:USERID"
+        "hash_strategy": "CLIENT_IP_ONLY",
+        "hash_header": ""
     },
     "passive_health_check": {
         "interval": 1000,

--- a/test/integration/tests/clusters/detail/detail_test.go
+++ b/test/integration/tests/clusters/detail/detail_test.go
@@ -44,6 +44,13 @@ func TestClusters_Detail(t *testing.T) {
 	assert.NotContains(t, data, "scheduler")
 	assert.Contains(t, data, "llm_config")
 
+	sticky, ok := data["sticky_sessions"].(map[string]interface{})
+	if assert.True(t, ok, "sticky_sessions should be an object") {
+		assert.Equal(t, false, sticky["enabled"])
+		assert.Equal(t, "CLIENT_IP_ONLY", sticky["hash_strategy"])
+		assert.Equal(t, "", sticky["hash_header"])
+	}
+
 	t.Cleanup(func() {
 		testutil.DeleteCluster(clusterName)
 	})


### PR DESCRIPTION
…的 hash_header

问题：UI 创建集群时 sticky_sessions.enabled=false，默认 hash_strategy=CLIENT_ID_ONLY 且 hash_header=""，导致 BFE reload 时报 no HashHeader（yf-networks/ai-gateway-api#48）。

修复：
- normalizeStickySessions 默认 hash_strategy 改为 CLIENT_IP_ONLY，避免默认即非法。
- UpsertParam.Validate 增加校验：enabled=true 且 hash_strategy 为 CLIENT_ID_ONLY/CLIENT_ID_PREFERED 时，hash_header 必须非空。
- NewBfeClusterConf 增加兜底：disabled + 空 hash_header + CLIENT_ID 策略时， 输出到 BFE 的 HashStrategy 自动转为 CLIENT_IP_ONLY，兼容存量数据。
- 同步更新 OpenAPI/模型/集成测试设计文档及单元测试、集成测试断言。

Fixes yf-networks/ai-gateway-api#48